### PR TITLE
Fixed support of batch rpc calls

### DIFF
--- a/flask_jsonrpc/helpers.py
+++ b/flask_jsonrpc/helpers.py
@@ -27,19 +27,16 @@
 # POSSIBILITY OF SUCH DAMAGE.
 from functools import wraps
 
-from flask import current_app, request, jsonify, json
+from flask import current_app, request, make_response, json
 
 from flask_jsonrpc._compat import b, u, text_type
 from flask_jsonrpc.exceptions import InvalidCredentialsError, InvalidParamsError
 
 def jsonify_status_code(status_code, *args, **kw):
     """Returns a jsonified response with the specified HTTP status code.
-
-    The positional and keyword arguments are passed directly to the
-    :func:`flask.jsonify` function which creates the response.
-
     """
-    response = jsonify(*args, **kw)
+    response = make_response(json.dumps(*args, **kw))
+    response.mimetype = 'application/json'
     response.status_code = status_code
     return response
 

--- a/flask_jsonrpc/site.py
+++ b/flask_jsonrpc/site.py
@@ -283,6 +283,7 @@ class JSONRPCSite(object):
             if type(D) is list:
                 response = [self.response_dict(request, d, is_batch=True)[0] for d in D]
                 status = 200
+                return response, status
             else:
                 response, status = self.response_dict(request, D)
                 if response is None and (not 'id' in D or D['id'] is None): # a notification


### PR DESCRIPTION
According to [Flask Docs](http://flask.pocoo.org/docs/security/#json-security) it's not secure to respond a JSON with top-level array. But according to [JSON-RPC 2.0 Specification](http://www.jsonrpc.org/specification#batch) during batch requests it is possible to return array of Response objects. So, I've mocked flask.jsonify function in helper.