### PR TITLE
Encode instead of throwing a type error

### DIFF
--- a/flask_jsonrpc/site.py
+++ b/flask_jsonrpc/site.py
@@ -223,7 +223,7 @@ class JSONRPCSite(object):
             if not sum([isinstance(R, e) for e in \
                     string_types + integer_types + (dict, list, set, NoneType, bool)]):
                 try:
-                    rs = encoder.default(R) # ...or something this thing supports
+                    rs = encoder.encode(R) # ...or something this thing supports
                 except TypeError as exc:
                     raise TypeError('Return type not supported, for {0!r}'.format(R))
 


### PR DESCRIPTION
`JSONEncoder.default` just throws a `TypeError` unconditionally; this change calls `JSONEncoder.encode` which actually attempts to render the input.