### PR TITLE
Auth args

### DIFF
--- a/flask_jsonrpc/__init__.py
+++ b/flask_jsonrpc/__init__.py
@@ -178,7 +178,8 @@ class JSONRPC(object):
         to inject a "username" and "password" into the method arguments, the auth_args
         paramter would be [('username', 'String'), ('password', 'String')]
     """
-    def __init__(self, app=None, service_url='/api', auth_backend=authenticate, auth_args=None,
+    def __init__(self, app=None, service_url='/api', auth_backend=authenticate,
+                 auth_args=[('username', 'String'), ('password', 'String')],
                  site=default_site, enable_web_browsable_api=False):
         self.service_url = service_url
         self.browse_url = self._make_browse_url(service_url)

--- a/flask_jsonrpc/__init__.py
+++ b/flask_jsonrpc/__init__.py
@@ -233,9 +233,10 @@ class JSONRPC(object):
         def decorator(f):
             arg_names = getargspec(f)[0]
             X = {'name': name, 'arg_names': arg_names}
-            if authenticated and self.auth_arg_names is not None:
-                X['arg_names'] = self.auth_arg_names + X['arg_names']
-                X['name'] = _inject_args(X['name'], self.auth_arg_types)
+            if authenticated:
+                if self.auth_args is not None:
+                    X['arg_names'] = self.auth_arg_names + X['arg_names']
+                    X['name'] = _inject_args(X['name'], self.auth_arg_types)
                 _f = self.auth_backend(f, authenticated)
             else:
                 _f = f


### PR DESCRIPTION
I think this does a decent job of allowing users to specify their own set of args to use for authenticated methods. These changes are minimal, but add flexibility for the use of alternate argument names, or using other methods for authentication, i.e. HTTP headers in the auth_backend.
