### PR TITLE
Fix formatting of function docstrings in view

### DIFF
--- a/flask_jsonrpc/views/browse/templates/browse/partials/response_object.html
+++ b/flask_jsonrpc/views/browse/templates/browse/partials/response_object.html
@@ -7,7 +7,7 @@
         <h4 class="modal-title"><span class="glyphicon glyphicon-star"></span> {{module.name}}(<span ng-repeat="param in module.params">{{param.name}}: {{param.type}}<span ng-if="!$last">, </span></span>) -> {{module.return.type}}</h4>
       </div>
       <div class="modal-body">
-        <h5><b>Summary:</b> <span ng-if="!module.summary">None</span>{{module.summary}}</h5>
+        <h5><b>Summary:</b> <span ng-if="!module.summary">None</span><span style="white-space: pre-wrap;">{{module.summary}}</span></h5>
         <h5><b>Idempotent:</b> {{module.idempotent}}</h5>
         <ng-form name="nameDialog" novalidate role="form">
           <div class="form-group input-group-lg">


### PR DESCRIPTION
Newlines are ignored by html, and so do not show up when docstrings are printed.  Added some minimal css so that they are visible, but there will still be line-wrapping if necessary.