### PR TITLE
set data for jsonrpc exceptions

### DIFF
--- a/flask_jsonrpc/exceptions.py
+++ b/flask_jsonrpc/exceptions.py
@@ -52,7 +52,7 @@ class Error(Exception):
     data = None
     status = 200
 
-    def __init__(self, message=None, code=None):
+    def __init__(self, message=None, code=None, data=None):
         """Setup the Exception and overwrite the default message
         """
         super(Error, self).__init__()
@@ -60,6 +60,8 @@ class Error(Exception):
             self.message = message
         if code is not None:
             self.code = code
+        if data is not None:
+            self.data = data
 
     @property
     def json_rpc_format(self):


### PR DESCRIPTION
Allowing to set a value to "data" param in Exceptions Classes.

Reference for "data" param in response error object:  http://www.jsonrpc.org/specification#response_object

Examples:

Before: (always null value for data)
{
"message": "InvalidParamsError: Invalid params.",
 "code": -32602,
 **"data": null,**
 "name": "InvalidParamsError"
}

After: (setting a value for data, eg: more error details.) 
{
"message": "InvalidParamsError: Invalid params.",
 "code": -32602,
 **"data": "Host 'test' not found.",**
 "name": "InvalidParamsError"
}
