### PR TITLE
Fix exception message

### DIFF
--- a/flask_jsonrpc/exceptions.py
+++ b/flask_jsonrpc/exceptions.py
@@ -69,7 +69,7 @@ class Error(Exception):
         error = {
             'name': text_type(self.__class__.__name__),
             'code': self.code,
-            'message': '{0}: {1}'.format(text_type(self.__class__.__name__), text_type(self.message)),
+            'message': '{0}'.format(text_type(self.message)),
             'data': self.data
         }
 


### PR DESCRIPTION
Current exception message sends "Class Name" + "Message". 

According to [JSON-RPC specification,"the message SHOULD be limited to a concise single sentence "](http://www.jsonrpc.org/specification#response_object), so there is no need to exception class name be on the "message". However, class name is present on the field "name" already.

Current response:  
{
**"message": "InvalidParamsError: Invalid params.",** 
"code": -32602, 
"data": "Host 'test' not found.", 
"name": "InvalidParamsError"
}

After:

{
**"message": "Invalid params.",** 
"code": -32602, 
"data": "Host 'test' not found.", 
"name": "InvalidParamsError"
}
