### PR TITLE
Update version to allow installing from github

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -51,7 +51,7 @@ class PyTest(TestCommand):
 
 setup(
     name='Flask-JSONRPC',
-    version='0.3.1',
+    version='0.3.1.dev0',
     url='https://github.com/cenobites/flask-jsonrpc',
     license='New BSD License',
     author='Nycholas de Oliveira e Oliveira',


### PR DESCRIPTION
This will allow the current version of the project to be used as a target in a `setup.py`.  Right now, I am not sure you can install the version from github in a project, since the version here matches the version on pypi (both are 0.3.1).
