### PR TITLE
Fixed pypy-3.5 issue with BROKEN_PYPY_CTXMGR_EXIT

### DIFF
--- a/flask_jsonrpc/_compat.py
+++ b/flask_jsonrpc/_compat.py
@@ -170,28 +170,32 @@ def with_metaclass(meta, *bases):
     return metaclass('temporary_class', None, {})
 
 # Certain versions of pypy have a bug where clearing the exception stack
-# breaks the __exit__ function in a very peculiar way.  This is currently
-# true for pypy 2.2.1 for instance.  The second level of exception blocks
-# is necessary because pypy seems to forget to check if an exception
-# happened until the next bytecode instruction?
+# breaks the __exit__ function in a very peculiar way.  The second level of
+# exception blocks is necessary because pypy seems to forget to check if an
+# exception happened until the next bytecode instruction?
+#
+# Relevant PyPy bugfix commit:
+# https://bitbucket.org/pypy/pypy/commits/77ecf91c635a287e88e60d8ddb0f4e9df4003301
+# According to ronan on #pypy IRC, it is released in PyPy2 2.3 and later
+# versions.
+#
+# Ubuntu 14.04 has PyPy 2.2.1, which does exhibit this bug.
 BROKEN_PYPY_CTXMGR_EXIT = False
 if hasattr(sys, 'pypy_version_info'):
-    # I don't know if this thread exception clear issue is python3 relevant
-    # but there's no exc_clear in python3 so we should not perform *these*
-    # checks the same as python2 way
-    if sys.version_info < (3,):
-        class _Mgr(object):
-            def __enter__(self):
-                return self
-            def __exit__(self, *args):
+    class _Mgr(object):
+        def __enter__(self):
+            return self
+        def __exit__(self, *args):
+            if hasattr(sys, 'exc_clear'):
+                # Python 3 (PyPy3) doesn't have exc_clear
                 sys.exc_clear()
+    try:
         try:
-            try:
-                with _Mgr():
-                    raise AssertionError()
-            except:
-                raise
-        except TypeError:
-            BROKEN_PYPY_CTXMGR_EXIT = True
-        except AssertionError:
-            pass
+            with _Mgr():
+                raise AssertionError()
+        except:
+            raise
+    except TypeError:
+        BROKEN_PYPY_CTXMGR_EXIT = True
+    except AssertionError:
+        pass


### PR DESCRIPTION
There's no `sys.exc_clear()` in pypy3+, but code did not check python version. Just added a new condition to drop checks for python>=3.