### PR TITLE
Check if raw_data is unicode before try to encode

### DIFF
--- a/flask_jsonrpc/helpers.py
+++ b/flask_jsonrpc/helpers.py
@@ -76,8 +76,7 @@ def extract_raw_data_request(request):
 
     # Try charset from content-type
     encoding = request.charset if request.charset else 'utf-8'
-
-    if encoding:
+    if encoding and not isinstance(raw_data, unicode):
         try:
             return text_type(raw_data, encoding)
         except UnicodeError:


### PR DESCRIPTION
Moderm Flask versions has unicode headers. 
When flask-jsonrpc try to convert, cause exception.
This change avoids error by not trying to convert something that is already unicode.