### PR TITLE
Extract register method

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: all clean test test-deps env env2
+.PHONY: all clean test release publish-test publish env
 
 VIRTUALENV_EXISTS := $(shell [ -d .venv ] && echo 1 || echo 0)
 
@@ -9,13 +9,20 @@ clean:
 	@python setup.py clean
 	@find . -name "*.pyc" | xargs rm -rf
 	@find . -name "__pycache__" | xargs rm -rf
-	@rm -rf .coverage Flask_JSONRPC.egg-info/ htmlcov/ build/
+	@find . -name ".coverage" | xargs rm -rf
+	@rm -rf .coverage .eggs/ .mypy_cache/ .pytest_cache/ Flask_JSONRPC.egg-info/ htmlcov/ build/ dist/
 
-test: clean test-deps
+test: clean
 	@python setup.py test
 
-test-deps:
-	@pip install -r requirements_test.pip
+release: clean
+	@python setup.py build sdist bdist_wheel
+
+publish-test: clean release
+	@twine upload --repository testpypi dist/*
+
+publish: clean release
+	@twine upload dist/*
 
 env:
 ifeq ($(VIRTUALENV_EXISTS), 0)

--- a/examples/register_view_func/run.py
+++ b/examples/register_view_func/run.py
@@ -1,0 +1,101 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+# Copyright (c) 2012-2020, Cenobit Technologies, Inc. http://cenobit.es/
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# * Redistributions of source code must retain the above copyright notice,
+#    this list of conditions and the following disclaimer.
+# * Redistributions in binary form must reproduce the above copyright notice,
+#    this list of conditions and the following disclaimer in the documentation
+#    and/or other materials provided with the distribution.
+# * Neither the name of the Cenobit Technologies nor the names of
+#    its contributors may be used to endorse or promote products derived from
+#    this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+# isort:skip_file
+import os
+import sys
+from typing import Any, Dict, List, Union, NoReturn, Optional
+from numbers import Real
+
+from flask import Flask
+
+PROJECT_DIR, PROJECT_MODULE_NAME = os.path.split(os.path.dirname(os.path.realpath(__file__)))
+
+FLASK_JSONRPC_PROJECT_DIR = os.path.join(PROJECT_DIR, os.pardir)
+if os.path.exists(FLASK_JSONRPC_PROJECT_DIR) and FLASK_JSONRPC_PROJECT_DIR not in sys.path:
+    sys.path.append(FLASK_JSONRPC_PROJECT_DIR)
+
+from flask_jsonrpc import JSONRPC  # noqa: E402   pylint: disable=C0413
+
+
+class MyApp:
+    def index(self) -> str:
+        return 'Welcome to Flask JSON-RPC'
+
+    def greeting(self, name: str) -> str:
+        return 'Hello {0}'.format(name)
+
+    def args_validate(self, a1: int, a2: str, a3: bool, a4: List[Any], a5: Dict[Any, Any]) -> str:
+        return 'Number: {0}, String: {1}, Boolean: {2}, Array: {3}, Object: {4}'.format(a1, a2, a3, a4, a5)
+
+    def notify(self, _string: Optional[str] = None) -> None:
+        pass
+
+    def fails(self, _string: Optional[str] = None) -> NoReturn:
+        raise ValueError('example of fail')
+
+    def sum_(self, a: Real, b: Real) -> Real:
+        return a + b
+
+    @classmethod
+    def multiply(cls, a: float, b: float) -> float:
+        return a * b
+
+    @staticmethod
+    def divide(a: Real, b: Real) -> Real:
+        return a / float(b)
+
+
+app = Flask(__name__)
+jsonrpc = JSONRPC(app, '/api', enable_web_browsable_api=True)
+
+
+@jsonrpc.method('subtract')
+def subtract(a: Union[int, float], b: Union[int, float]) -> Union[int, float]:
+    return a - b
+
+
+def hello_default_args(string: str = 'Flask JSON-RPC') -> str:
+    return 'We salute you {0}'.format(string)
+
+
+jsonrpc.register(hello_default_args)
+
+my_app = MyApp()
+jsonrpc.register(my_app.index)
+jsonrpc.register(my_app.greeting)
+jsonrpc.register(my_app.args_validate)
+jsonrpc.register(my_app.notify)
+jsonrpc.register(my_app.fails)
+jsonrpc.register(my_app.sum_, name='sum')
+jsonrpc.register(my_app.multiply)
+jsonrpc.register(my_app.divide)
+
+
+if __name__ == '__main__':
+    app.run(host='0.0.0.0', debug=True)

--- a/flask_jsonrpc/__init__.py
+++ b/flask_jsonrpc/__init__.py
@@ -29,4 +29,4 @@ from .app import JSONRPC
 from .views import JSONRPCView
 from .blueprints import JSONRPCBlueprint
 
-__version__ = '1.0.2'
+__version__ = '1.1.0-dev'

--- a/flask_jsonrpc/app.py
+++ b/flask_jsonrpc/app.py
@@ -25,7 +25,7 @@
 # CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
 # ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
-from typing import TYPE_CHECKING, Type, Union, Optional
+from typing import TYPE_CHECKING, Any, Type, Union, Callable, Optional
 
 from flask import Flask
 
@@ -75,6 +75,11 @@ class JSONRPC(JSONRCPDecoratorMixin):
             ),
         )
         self.register_browse(app, self)
+
+    def register(
+        self, view_func: Callable[..., Any], name: Optional[str] = None, validate: bool = True, **options: Any
+    ) -> None:
+        self.register_view_function(view_func, name, validate, **options)
 
     def register_blueprint(
         self, app: Flask, jsonrpc_app: 'JSONRPCBlueprint', url_prefix: str, enable_web_browsable_api: bool = False

--- a/flask_jsonrpc/site.py
+++ b/flask_jsonrpc/site.py
@@ -185,7 +185,7 @@ class JSONRPCSite:
             # other sized tuples are not allowed
             else:
                 raise TypeError(
-                    'The view function did not return a valid response tuple.'
+                    'the view function did not return a valid response tuple.'
                     ' The tuple must have the form (body, status, headers),'
                     ' (body, status), or (body, headers).'
                 )

--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,7 @@ with open('README.md', 'r') as fh:
 
 setuptools.setup(
     name='Flask-JSONRPC',
-    version='1.0.2',
+    version='1.1.0-dev',
     url='https://github.com/cenobites/flask-jsonrpc',
     license='New BSD License',
     author='Nycholas de Oliveira e Oliveira',

--- a/tests/apptest.py
+++ b/tests/apptest.py
@@ -33,6 +33,30 @@ from flask import Flask
 from flask_jsonrpc import JSONRPC
 
 
+class App:
+    def index(self, name: str = 'Flask JSON-RPC') -> str:
+        return 'Hello {0}'.format(name)
+
+    @staticmethod
+    def greeting(name: str = 'Flask JSON-RPC') -> str:
+        return 'Hello {0}'.format(name)
+
+    @classmethod
+    def hello(cls, name: str = 'Flask JSON-RPC') -> str:
+        return 'Hello {0}'.format(name)
+
+    def echo(self, string: str, _some: Any = None) -> str:
+        return string
+
+    def notify(self, _string: str = None) -> None:
+        pass
+
+    def fails(self, n: int) -> int:
+        if n % 2 == 0:
+            return n
+        raise ValueError('number is odd')
+
+
 def jsonrcp_decorator(fn):
     @functools.wraps(fn)
     def wrapped(*args, **kwargs):
@@ -104,5 +128,13 @@ def create_app(test_config=None):  # noqa: C901  pylint: disable=W0612
     @jsonrpc.method('jsonrpc.returnStatusCodeAndHeaders')
     def return_status_code_and_headers(s: str) -> Tuple[str, int, Dict[str, Any]]:
         return 'Status Code and Headers {0}'.format(s), 400, {'X-JSONRPC': '1'}
+
+    class_app = App()
+    jsonrpc.register(class_app.index, name='classapp.index')
+    jsonrpc.register(class_app.greeting)
+    jsonrpc.register(class_app.hello)
+    jsonrpc.register(class_app.echo)
+    jsonrpc.register(class_app.notify)
+    jsonrpc.register(class_app.fails)
 
     return app

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -307,6 +307,40 @@ def test_app_return_status_code_and_headers(client):
     assert ('X-JSONRPC', '1') in list(rv.headers)
 
 
+def test_app_class(client):
+    rv = client.post('/api', json={'id': 1, 'jsonrpc': '2.0', 'method': 'classapp.index'})
+    assert rv.json == {'id': 1, 'jsonrpc': '2.0', 'result': 'Hello Flask JSON-RPC'}
+    assert rv.status_code == 200
+
+    rv = client.post('/api', json={'id': 1, 'jsonrpc': '2.0', 'method': 'greeting', 'params': ['Python']})
+    assert rv.json == {'id': 1, 'jsonrpc': '2.0', 'result': 'Hello Python'}
+    assert rv.status_code == 200
+
+    rv = client.post('/api', json={'id': 1, 'jsonrpc': '2.0', 'method': 'hello', 'params': {'name': 'Flask'}})
+    assert rv.json == {'id': 1, 'jsonrpc': '2.0', 'result': 'Hello Flask'}
+    assert rv.status_code == 200
+
+    rv = client.post('/api', json={'id': 1, 'jsonrpc': '2.0', 'method': 'echo', 'params': ['Python', 1]})
+    assert rv.json == {'id': 1, 'jsonrpc': '2.0', 'result': 'Python'}
+    assert rv.status_code == 200
+
+    rv = client.post('/api', json={'jsonrpc': '2.0', 'method': 'notify', 'params': ['Python']})
+    assert rv.status_code == 204
+
+    rv = client.post('/api', json={'id': 1, 'jsonrpc': '2.0', 'method': 'fails', 'params': [13]})
+    assert rv.json == {
+        'id': 1,
+        'jsonrpc': '2.0',
+        'error': {
+            'code': -32000,
+            'data': {'message': 'number is odd'},
+            'message': 'Server error',
+            'name': 'ServerError',
+        },
+    }
+    assert rv.status_code == 500
+
+
 def test_app_system_describe(client):
     rv = client.post('/api', json={'id': 1, 'jsonrpc': '2.0', 'method': 'system.describe'})
     assert rv.json['id'] == 1
@@ -382,6 +416,37 @@ def test_app_system_describe(client):
             'return': {'type': 'Array'},
             'summary': None,
         },
+        {
+            'name': 'classapp.index',
+            'params': [{'name': 'name', 'type': 'String'}],
+            'return': {'type': 'String'},
+            'summary': None,
+        },
+        {
+            'name': 'greeting',
+            'params': [{'name': 'name', 'type': 'String'}],
+            'return': {'type': 'String'},
+            'summary': None,
+        },
+        {
+            'name': 'hello',
+            'params': [{'name': 'name', 'type': 'String'}],
+            'return': {'type': 'String'},
+            'summary': None,
+        },
+        {
+            'name': 'echo',
+            'params': [{'name': 'string', 'type': 'String'}, {'name': '_some', 'type': 'Object'}],
+            'return': {'type': 'String'},
+            'summary': None,
+        },
+        {
+            'name': 'notify',
+            'params': [{'name': '_string', 'type': 'String'}],
+            'return': {'type': 'Null'},
+            'summary': None,
+        },
+        {'name': 'fails', 'params': [{'name': 'n', 'type': 'Number'}], 'return': {'type': 'Number'}, 'summary': None},
     ]
 
     assert rv.status_code == 200


### PR DESCRIPTION
Now you can register a method (function or class method) with alias
`JSONRPC.register(view_func, name='some.name')`.

For example:

```
from flask_jsonrpc import JSONRPC

class MyApp:
    def index(self) -> str:
        return 'Welcome to Flask JSON-RPC'

app = Flask(__name__)
jsonrpc = JSONRPC(app, '/api', enable_web_browsable_api=True)

@jsonrpc.method('subtract')
def subtract(a: int, b: int) -> int:
    return a - b

def hello_default_args(string: str = 'Flask JSON-RPC') -> str:
    return 'We salute you {0}'.format(string)

jsonrpc.register(hello_default_args)

my_app = MyApp()
jsonrpc.register(my_app.index)

app.run(host='0.0.0.0', debug=True)
```

Resolves: #60

