### PR TITLE
Add RPC Batch

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -17,6 +17,7 @@ exclude_lines =
     # Don't complain if non-runnable code isn't run:
     if 0:
     if __name__ == .__main__.:
+    if current_app:
     if current_app\.config\[.DEBUG.\]:
     if app\.config\[.DEBUG.\]
 

--- a/flask_jsonrpc/helpers.py
+++ b/flask_jsonrpc/helpers.py
@@ -26,7 +26,8 @@
 # ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
 import itertools
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, Dict
+from operator import getitem
 
 from .types import Types, Object
 
@@ -81,6 +82,55 @@ def from_python_type(tp: Any) -> 'JSONRPCNewType':
         if t.check_type(tp):
             return t
     return Object
+
+
+def get(obj: Dict[str, Any], path: str, default: Any = None) -> Any:
+    """Get the value at any depth of a nested object based on the path
+    described by `path`. If path doesn't exist, `default` is returned.
+    Args:
+        obj (dict): Object to process.
+        path (str): List or ``.`` delimited string of path describing
+            path.
+    Keyword Arguments:
+        default (mixed): Default value to return if path doesn't exist.
+            Defaults to ``None``.
+    Returns:
+        mixed: Value of `obj` at path.
+
+    Example:
+
+    >>> get(None, 'a')
+
+    >>> get(None, 'a', 'default')
+    'default'
+    >>> get({'a': 1}, 'a')
+    1
+    >>> get({'a': 1}, 'b')
+
+    >>> get({'a': 1}, 'b', 'default')
+    'default'
+    >>> get({'a': {'b': {'c': 1}}}, 'a.b.c')
+    1
+    >>> get({}, 'a.b.c')
+
+    >>> get([], 'a.b.c')
+
+    >>> get([], 'a.b.c', None)
+
+    """
+    if obj is None:
+        return default
+    if not isinstance(obj, dict):
+        return default
+
+    obj_val = obj
+    keys = path.split('.')
+    for key in keys:
+        try:
+            obj_val = getitem(obj_val, key)
+        except KeyError:
+            return default
+    return obj_val
 
 
 if __name__ == '__main__':

--- a/requirements_test.pip
+++ b/requirements_test.pip
@@ -7,5 +7,6 @@ mock
 coverage
 pytest
 pytest-cov
+pytest-sugar
 coveralls
 typeguard

--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,7 @@ with open('README.md', 'r') as fh:
 
 setuptools.setup(
     name='Flask-JSONRPC',
-    version='1.1.0-dev',
+    version='1.1.0.dev0',
     url='https://github.com/cenobites/flask-jsonrpc',
     license='New BSD License',
     author='Nycholas de Oliveira e Oliveira',
@@ -48,7 +48,7 @@ setuptools.setup(
     python_requires='>= 3.6',
     install_requires=['Flask>=1.0.0', 'typeguard'],
     setup_requires=['pytest-runner'],
-    tests_require=['mock', 'coverage', 'pytest', 'pytest-cov', 'typeguard'],
+    tests_require=['mock', 'coverage', 'pytest', 'pytest-cov', 'pytest-sugar', 'typeguard'],
     classifiers=[
         'Environment :: Web Environment',
         'Intended Audience :: Developers',


### PR DESCRIPTION
To send several Request objects at the same time, the Client MAY
send an Array filled with Request objects.

The Server should respond with an Array containing the corresponding
Response objects, after all of the batch Request objects have been
processed. A Response object SHOULD exist for each Request object,
except that there SHOULD NOT be any Response objects for notifications.
The Server MAY process a batch rpc call as a set of concurrent tasks,
processing them in any order and with any width of parallelism.

The Response objects being returned from a batch call MAY be returned
in any order within the Array. The Client SHOULD match contexts
between the set of Request objects and the resulting set of Response
objects based on the id member within each Object.

If the batch rpc call itself fails to be recognized as an valid JSON
or as an Array with at least one value, the response from the Server
MUST be a single Response object. If there are no Response objects
contained within the Response array as it is to be sent to the client,
the server MUST NOT return an empty Array and should return nothing at
all.

From: https://www.jsonrpc.org/specification#batch

Resolve: #80
