### PR TITLE
Adicional HTTP Headers for JSON-RPC Over HTTP

### DIFF
--- a/src/flask_jsonrpc/site.py
+++ b/src/flask_jsonrpc/site.py
@@ -92,7 +92,7 @@ class JSONRPCSite:
         https://github.com/pallets/werkzeug/blob/master/src/werkzeug/wrappers/json.py#L54
         """
         mt = request.mimetype
-        return mt == 'application/json' or mt.startswith('application/') and mt.endswith('+json')
+        return mt == 'application/json' or mt == 'application/json-rpc' or mt.startswith('application/') and mt.endswith('+json')
 
     def register(self, name: str, view_func: Callable[..., Any]) -> None:
         self.view_funcs[name] = view_func


### PR DESCRIPTION
According to JSON-RPC Over HTTP[1] documentation:

```
[3.3   HTTP Header](https://www.jsonrpc.org/historical/json-rpc-over-http.html#id13)

Requirements:

Regardless of whether a remote procedure call is made using HTTP GET or POST, the HTTP request message MUST specify the following headers:

    Content-Type SHOULD be 'application/json-rpc' but MAY be 'application/json' or 'application/jsonrequest'
    The Content-Length MUST be specified and correct according to the guidelines and rules laid out in Section 4.4, Message Length, of the [HTTP](http://www.ietf.org/rfc/rfc2616.txt) specification.
    The Accept MUST be specified and SHOULD read 'application/json-rpc' but MAY be 'application/json' or 'application/jsonrequest'.
```

[1] - https://www.jsonrpc.org/historical/json-rpc-over-http.html#id13