### PR TITLE
Replace pytest-runner with tox

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ clean:
 	@rm -rf .coverage .eggs/ .mypy_cache/ .pytest_cache/ .tox/ src/Flask_JSONRPC.egg-info/ htmlcov/ build/ dist/
 
 test: clean
-	@python setup.py test
+	@python -m tox
 
 test-release: clean test
 	@docker-compose -f docker-compose.test.yml build --build-arg VERSION=$(shell date +%s)

--- a/setup.py
+++ b/setup.py
@@ -42,8 +42,8 @@ setuptools.setup(
         'async': ['Flask[async]>=1.0.0,<3.0'],
         'dotenv': ['Flask[dotenv]>=1.0.0,<3.0'],
     },
-    setup_requires=['pytest-runner'],
     tests_require=[
+        'tox==3.25.0',
         'mock==4.0.3',
         'coverage==6.3.2;python_version>"3.6"',
         'coverage<6.2;python_version<="3.6"',


### PR DESCRIPTION
This isn't a build requirement so it shouldn't be under `setup_requires`.

Migrate to `tox` as well since `pytest-runner` is deprecated.
