### PR TITLE
Bump dependencies from dependabot

### DIFF
--- a/requirements/ci.txt
+++ b/requirements/ci.txt
@@ -1,7 +1,7 @@
 # Code formatter
 # ------------------------------------------------------------------------------
 black==22.10.0;python_version>"3.6"  # https://github.com/psf/black
-pyupgrade==3.1.0;python_version>"3.6"  # https://github.com/asottile/pyupgrade
+pyupgrade==3.2.2;python_version>"3.6"  # https://github.com/asottile/pyupgrade
 
 # Code quality
 # ------------------------------------------------------------------------------
@@ -18,14 +18,14 @@ flake8-implicit-str-concat<0.3.0;python_version<="3.6"
 
 # Code linter
 # ------------------------------------------------------------------------------
-pylint==2.15.4;python_version>"3.6"  # https://github.com/PyCQA/pylint
+pylint==2.15.5;python_version>"3.6"  # https://github.com/PyCQA/pylint
 pylint<=2.13.9;python_version<="3.6"
 
 # Type check
 # ------------------------------------------------------------------------------
-mypy==0.982;python_version>"3.6"  # https://github.com/python/mypy
+mypy==0.990;python_version>"3.6"  # https://github.com/python/mypy
 pytype==2022.10.13;python_version>"3.6"  # https://github.com/google/pytype
-types_setuptools==65.5.0.2  # https://github.com/python/typeshed
+types_setuptools==65.5.0.3  # https://github.com/python/typeshed
 typeguard==2.13.3  # https://github.com/agronholm/typeguard
 
 # Security check

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -1,6 +1,6 @@
 # Testing
 # ------------------------------------------------------------------------------
-pytest==7.1.3;python_version>"3.6"  # https://github.com/pytest-dev/pytest
+pytest==7.2.0;python_version>"3.6"  # https://github.com/pytest-dev/pytest
 pytest<7;python_version<="3.6"
 pytest-cov==4.0.0  # https://github.com/pytest-dev/pytest-cov
 pytest-xdist==3.0.2  # https://github.com/pytest-dev/pytest-xdist

--- a/tox.ini
+++ b/tox.ini
@@ -21,7 +21,7 @@ commands = pre-commit run --all-files --show-diff-on-failure
 
 [testenv:typing]
 deps =
-    mypy==0.982
+    mypy==0.990
     pytype==2022.10.13
 commands =
     mypy --install-types --non-interactive src/


### PR DESCRIPTION
Bump types-setuptools from 65.5.0.2 to 65.5.0.3 in /requirements #328 
Bump pylint from 2.15.4 to 2.15.5 in /requirements #327 
Bump mypy from 0.982 to 0.990 in /requirements #326 
Bump pyupgrade from 3.1.0 to 3.2.2 in /requirements #325 
Bump pytest from 7.1.3 to 7.2.0 in /requirements #324 