### PR TITLE
Bump versions from dependabot alerts

### DIFF
--- a/.github/workflows/codeql_analysis.yml
+++ b/.github/workflows/codeql_analysis.yml
@@ -29,12 +29,12 @@ jobs:
         languages: ${{ matrix.language }}
         # queries: security-extended,security-and-quality
     - name: Setup Python
-      if: ${{  matrix.language == 'python' }}
+      if: ${{ matrix.language == 'python' }}
       uses: actions/setup-python@v4
       with:
         python-version: '3.10'
     - name: Build Application using script
-      if: ${{  matrix.language == 'python' }}
+      if: ${{ matrix.language == 'python' }}
       run: |
         python -m pip install --upgrade pip setuptools build
         python -m build

--- a/.github/workflows/on_update.yml
+++ b/.github/workflows/on_update.yml
@@ -21,7 +21,7 @@ jobs:
       fail-fast: false
       matrix:
         platform:
-          - ubuntu-latest
+          - ubuntu-20.04
         python-version: ["3.6", "3.7", "3.8", "3.9"]
     steps:
     - name: Checkout source at ${{ matrix.platform }}
@@ -37,11 +37,11 @@ jobs:
       run: |
         flake8 src/ tests/
     - name: Run pylint
-      if: ${{  matrix.platform == 'ubuntu-latest' && matrix.python-version == '3.6' }}
+      if: ${{ matrix.python-version == '3.6' }}
       run: |
         pylint -d unused-import,no-self-use,bad-option-value src/ tests/
     - name: Run pylint
-      if: ${{  matrix.platform == 'ubuntu-latest' && matrix.python-version != '3.6' }}
+      if: ${{ matrix.python-version != '3.6' }}
       run: |
         pylint src/ tests/
 
@@ -52,7 +52,7 @@ jobs:
       fail-fast: false
       matrix:
         platform:
-          - ubuntu-latest
+          - ubuntu-20.04
         python-version: ["3.6", "3.7", "3.8", "3.9"]
     steps:
     - name: Checkout source at ${{ matrix.platform }}

--- a/.github/workflows/pre_release.yml
+++ b/.github/workflows/pre_release.yml
@@ -16,7 +16,7 @@ jobs:
       fail-fast: false
       matrix:
         platform:
-          - ubuntu-latest
+          - ubuntu-20.04
         python-version: ["3.6", "3.7", "3.8", "3.9", "3.10"]
     steps:
     - name: Checkout source at ${{ matrix.platform }}
@@ -109,7 +109,7 @@ jobs:
       fail-fast: false
       matrix:
         platform:
-          - ubuntu-latest
+          - ubuntu-20.04
           - macos-latest
           - windows-latest
         python-version: ["3.6", "3.7", "3.8", "3.9", "3.10"]
@@ -131,7 +131,7 @@ jobs:
       run: |
         py.test
     - name: Upload coverage JUint report
-      if: ${{ matrix.platform == 'ubuntu-latest' && matrix.python-version == '3.10' }}
+      if: ${{ matrix.platform == 'ubuntu-20.04' && matrix.python-version == '3.10' }}
       uses: actions/upload-artifact@v3
       with:
         name: test-n-coverage-report
@@ -181,7 +181,7 @@ jobs:
       fail-fast: false
       matrix:
         platform:
-          - ubuntu-latest
+          - ubuntu-20.04
           - macos-latest
           - windows-latest
         python-version: ["3.6", "3.7", "3.8", "3.9", "3.10"]
@@ -197,12 +197,12 @@ jobs:
         python -m pip install --upgrade pip setuptools build
         python -m build --outdir dist-${{ matrix.platform }}-${{ matrix.python-version }}
     - name: Tar build and wheel distributions files
-      if: ${{  matrix.platform == 'ubuntu-latest' && matrix.python-version == '3.10' }}
+      if: ${{  matrix.platform == 'ubuntu-20.04' && matrix.python-version == '3.10' }}
       run: |
         mv dist-${{ matrix.platform }}-${{ matrix.python-version }} dist
         tar -cvf dist.tar dist
     - name: Upload build and wheel distributions files
-      if: ${{  matrix.platform == 'ubuntu-latest' && matrix.python-version == '3.10' }}
+      if: ${{  matrix.platform == 'ubuntu-20.04' && matrix.python-version == '3.10' }}
       uses: actions/upload-artifact@v3
       with:
         name: pre-release-build

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -5,7 +5,7 @@ default_language_version:
   python: python3.10
 repos:
 - repo: https://github.com/pre-commit/pre-commit-hooks
-  rev: v4.3.0
+  rev: v4.4.0
   hooks:
     - id: check-byte-order-marker
     - id: check-case-conflict
@@ -17,37 +17,37 @@ repos:
     - id: mixed-line-ending
     - id: trailing-whitespace
 - repo: https://github.com/asottile/pyupgrade
-  rev: v3.2.2
+  rev: v3.3.1
   hooks:
     - id: pyupgrade
       args: ['--py36-plus']
 - repo: https://github.com/psf/black
-  rev: 22.10.0
+  rev: 23.1.0
   hooks:
     - id: black
       args: ['--safe']
 - repo: https://github.com/asottile/blacken-docs
-  rev: v1.12.1
+  rev: 1.13.0
   hooks:
     - id: blacken-docs
       additional_dependencies:
         - black==22.10.0
 - repo: https://github.com/PyCQA/isort
-  rev: 5.10.1
+  rev: 5.12.0
   hooks:
     - id: isort
 - repo: https://github.com/PyCQA/flake8
-  rev: 5.0.4
+  rev: 6.0.0
   hooks:
     - id: flake8
       additional_dependencies:
-        - flake8-isort==5.0.0
+        - flake8-isort==6.0.0
         - flake8-bugbear==22.10.27
-        - flake8-pyi==22.10.0
-        - flake8-quotes==3.3.1
+        - flake8-pyi==23.3.0
+        - flake8-quotes==3.3.2
         - flake8-implicit-str-concat==0.3.0
       args: ['--config=setup.cfg']
 - repo: https://github.com/PyCQA/pylint
-  rev: v2.15.5
+  rev: v2.17.0
   hooks:
     - id: pylint

--- a/requirements/ci.txt
+++ b/requirements/ci.txt
@@ -5,33 +5,34 @@ pyupgrade==3.2.2;python_version>"3.6"  # https://github.com/asottile/pyupgrade
 
 # Code quality
 # ------------------------------------------------------------------------------
-flake8==5.0.4  # https://github.com/PyCQA/flake8
-flake8-isort==5.0.0;python_version>"3.6"  # https://github.com/gforcada/flake8-isort
+flake8==6.0.0;python_version>"3.7"  # https://github.com/PyCQA/flake8
+flake8<6.0.0;python_version<="3.7"
+flake8-isort==6.0.0;python_version>"3.6"  # https://github.com/gforcada/flake8-isort
 flake8-isort<5.0.0;python_version<="3.6"
 isort>=4.2.5,<6;python_version<="3.6"  # https://github.com/PyCQA/isort
 flake8-bugbear==22.10.27;python_version>"3.6"  # https://github.com/PyCQA/flake8-bugbear
 flake8-bugbear<22.10;python_version<="3.6"
-flake8-pyi==22.10.0;python_version>"3.6"  # https://github.com/ambv/flake8-pyi
-flake8-quotes==3.3.1  # https://github.com/zheller/flake8-quotes
+flake8-pyi==23.3.0;python_version>"3.6"  # https://github.com/ambv/flake8-pyi
+flake8-quotes==3.3.2  # https://github.com/zheller/flake8-quotes
 flake8-implicit-str-concat==0.3.0;python_version>"3.6"  # https://github.com/keisheiled/flake8-implicit-str-concat
 flake8-implicit-str-concat<0.3.0;python_version<="3.6"
 
 # Code linter
 # ------------------------------------------------------------------------------
-pylint==2.15.5;python_version>"3.6"  # https://github.com/PyCQA/pylint
+pylint==2.16.4;python_version>"3.6"  # https://github.com/PyCQA/pylint
 pylint<2.14.0;python_version<="3.6"
 
 # Type check
 # ------------------------------------------------------------------------------
 mypy==0.991;python_version>"3.6"  # https://github.com/python/mypy
 pytype==2022.10.13;python_version>"3.6"  # https://github.com/google/pytype
-types_setuptools==65.5.0.3  # https://github.com/python/typeshed
+types_setuptools==67.6.0.3  # https://github.com/python/typeshed
 typeguard==2.13.3  # https://github.com/agronholm/typeguard
 
 # Security check
 # ------------------------------------------------------------------------------
 bandit==1.7.4;python_version>"3.6"  # https://github.com/PyCQA/bandit
-safety==2.3.1;python_version>"3.6"  # https://github.com/pyupio/safety
+safety==2.3.5;python_version>"3.6"  # https://github.com/pyupio/safety
 
 # Code quality
 # ------------------------------------------------------------------------------

--- a/requirements/docs.txt
+++ b/requirements/docs.txt
@@ -1,10 +1,10 @@
 # Documentation
 # ------------------------------------------------------------------------------
-Sphinx==5.3.0
+Sphinx==6.1.3
 sphinx-tabs==3.4.1
 sphinx-issues==3.0.1
 sphinxcontrib-log-cabinet==1.0.1
 
 # Pallets
 # ------------------------------------------------------------------------------
-Pallets-Sphinx-Themes==2.0.2
+Pallets-Sphinx-Themes==2.0.3

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -3,11 +3,12 @@
 pytest==7.2.0;python_version>"3.6"  # https://github.com/pytest-dev/pytest
 pytest<7;python_version<="3.6"
 pytest-cov==4.0.0  # https://github.com/pytest-dev/pytest-cov
-pytest-xdist==3.0.2  # https://github.com/pytest-dev/pytest-xdist
+pytest-xdist==3.2.1;python_version>"3.6"  # https://github.com/pytest-dev/pytest-xdist
+pytest-xdist<=3.0.2;python_version<="3.6"
 pytest-sugar==0.9.6  # https://github.com/Frozenball/pytest-sugar
 pytest-env==0.8.1;python_version>"3.6"  # https://github.com/MobileDynasty/pytest-env
 pytest-env<0.7.0;python_version<="3.6"
-mock==4.0.3  # https://github.com/testing-cabal/mock
+mock==5.0.1  # https://github.com/testing-cabal/mock
 
 # Type check
 # ------------------------------------------------------------------------------

--- a/src/flask_jsonrpc/wrappers.py
+++ b/src/flask_jsonrpc/wrappers.py
@@ -73,13 +73,13 @@ class JSONRPCDecoratorMixin:
         fn = self._get_function(view_func)
         fn_annotations = t.get_type_hints(fn)
         method_name = getattr(fn, '__name__', '<noname>') if not name else name
-        setattr(fn, 'jsonrpc_method_name', method_name)  # noqa: B010
-        setattr(fn, 'jsonrpc_method_sig', fn_annotations)  # noqa: B010
-        setattr(fn, 'jsonrpc_method_return', fn_annotations.pop('return', None))  # noqa: B010
-        setattr(fn, 'jsonrpc_method_params', fn_annotations)  # noqa: B010
-        setattr(fn, 'jsonrpc_validate', validate)  # noqa: B010
-        setattr(fn, 'jsonrpc_options', options)  # noqa: B010
         view_func_wrapped = typechecked(view_func) if validate else view_func
+        setattr(view_func_wrapped, 'jsonrpc_method_name', method_name)  # noqa: B010
+        setattr(view_func_wrapped, 'jsonrpc_method_sig', fn_annotations)  # noqa: B010
+        setattr(view_func_wrapped, 'jsonrpc_method_return', fn_annotations.pop('return', None))  # noqa: B010
+        setattr(view_func_wrapped, 'jsonrpc_method_params', fn_annotations)  # noqa: B010
+        setattr(view_func_wrapped, 'jsonrpc_validate', validate)  # noqa: B010
+        setattr(view_func_wrapped, 'jsonrpc_options', options)  # noqa: B010
         self.get_jsonrpc_site().register(method_name, view_func_wrapped)
         return view_func_wrapped
 

--- a/tox.ini
+++ b/tox.ini
@@ -34,7 +34,7 @@ commands =
 basepython=python3.10
 deps =
     bandit==1.7.4
-    safety==2.1.1
+    safety==2.3.5
 commands =
     safety check
     bandit -r src/


### PR DESCRIPTION
Bump pylint from 2.15.5 to 2.16.4 in /requirements #368 
Bump types-setuptools from 65.5.0.3 to 67.5.0.0 in /requirements #366 
Bump flake8-isort from 5.0.0 to 6.0.0 in /requirements #347 
Bump safety from 2.3.1 to 2.3.5 in /requirements #344 
Bump flake8 from 5.0.4 to 6.0.0 in /requirements #337