### PR TITLE
Add new param to allow/disallow JSON-RPC Notification

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,3 +1,4 @@
+<!--
 ## The seven rules of a great Git commit message
 
 :: Keep in mind: This has all been said before.
@@ -43,3 +44,4 @@ See also: #456, #789
 ```
 
 More details: https://chris.beams.io/posts/git-commit/.
+-->

--- a/.pylintrc
+++ b/.pylintrc
@@ -352,4 +352,4 @@ exclude-protected=_asdict,_fields,_replace,_source,_make
 
 # Exceptions that will emit a warning when being caught. Defaults to
 # "Exception"
-overgeneral-exceptions=Exception
+overgeneral-exceptions=builtins.Exception

--- a/examples/minimal/minimal.py
+++ b/examples/minimal/minimal.py
@@ -72,6 +72,11 @@ def notify(_string: Optional[str] = None) -> None:
     pass
 
 
+@jsonrpc.method('App.notNotify', notification=False)
+def not_notify(string: str) -> str:
+    return f'Not allow notification: {string}'
+
+
 @jsonrpc.method('App.fails')
 def fails(_string: Optional[str] = None) -> NoReturn:
     raise ValueError('example of fail')

--- a/src/flask_jsonrpc/app.py
+++ b/src/flask_jsonrpc/app.py
@@ -75,10 +75,8 @@ class JSONRPC(JSONRPCDecoratorMixin):
         )
         self.register_browse(app, self)
 
-    def register(
-        self, view_func: t.Callable[..., t.Any], name: t.Optional[str] = None, validate: bool = True, **options: t.Any
-    ) -> None:
-        self.register_view_function(view_func, name, validate, **options)
+    def register(self, view_func: t.Callable[..., t.Any], name: t.Optional[str] = None, **options: t.Any) -> None:
+        self.register_view_function(view_func, name, **options)
 
     def register_blueprint(
         self, app: Flask, jsonrpc_app: 'JSONRPCBlueprint', url_prefix: str, enable_web_browsable_api: bool = False

--- a/src/flask_jsonrpc/contrib/browse/static/js/apps/browse/controllers.js
+++ b/src/flask_jsonrpc/contrib/browse/static/js/apps/browse/controllers.js
@@ -16,9 +16,10 @@
         $scope.showFakeIntro = true;
         $scope.showContentLoaded = true;
         $scope.showToolbar = false;
+        $scope.showToolbarNotifyButton = true;
         $scope.breadcrumbs = breadcrumbs('Dashboard');
         $scope.response = responseExample;
-        $scope.response_object = responseObjectExample;
+        $scope.responseObject = responseObjectExample;
 
         $scope.$on('App:displayFakeIntro', function(event, display) {
             $scope.showFakeIntro = display;
@@ -34,6 +35,10 @@
 
         $scope.$on('App:displayToolbar', function(event, display) {
             $scope.showToolbar = display;
+        });
+
+        $scope.$on('App:displayToolbarNotifyButton', function(event, display) {
+            $scope.showToolbarNotifyButton = display;
         });
 
         $scope.showSpinner = function() {
@@ -67,11 +72,17 @@
             }, 750);
         });
 
+        $scope.goToDashboard = function() {
+            $scope.$emit('App:displayToolbar', false);
+            $scope.$emit('App:breadcrumb', 'Dashboard');
+            $location.path('/');
+        };
+
         $scope.showTooltip = function(module) {
             return Handlebars.template('menu-module-tooltip', module);
         };
 
-        $scope.showReponseObject = function(module) {
+        $scope.showResponseObject = function(module) {
             return $location.path(module.name);
         };
     }]);
@@ -98,7 +109,7 @@
         };
 
         $scope.hitEnter = function(evt) {
-            if (angular.equals(evt.keyCode,13) && !(angular.equals($scope.name,null) || angular.equals($scope.name,''))) {
+            if (angular.equals(evt.keyCode, 13) && !(angular.equals($scope.name, null) || angular.equals($scope.name, ''))) {
                 $scope.ok();
             }
         };
@@ -112,25 +123,26 @@
         $scope.module = module;
         $scope.$emit('App:displayToolbar', true);
         $scope.$emit('App:breadcrumb', module.name);
+        $scope.$emit('App:displayToolbarNotifyButton', module.options.notification);
 
         var RPCCall = function(module) {
             var payload = RPC.payload(module);
-            $scope.request_object = payload;
+            $scope.requestObject = payload;
             $scope.response = undefined;
-            $scope.response_object = undefined;
-            RPC.callWithPayload(payload).success(function(response_object, status, headers, config) { // success
-                var headers_pretty = headers();
-                headers_pretty.data = config.data;
+            $scope.responseObject = undefined;
+            RPC.callWithPayload(payload).success(function(responseObject, status, headers, config) { // success
+                var headersPretty = headers();
+                headersPretty.data = config.data;
 
-                $scope.response = {status: status, headers: headers_pretty, config: config};
-                $scope.response_object = response_object;
+                $scope.response = {status: status, headers: headersPretty, config: config};
+                $scope.responseObject = responseObject;
                 $scope.$emit('App:displayContentLoaded', false);
-            }).error(function(response_object, status, headers, config) { // error
-                var headers_pretty = headers();
-                headers_pretty.data = config.data;
+            }).error(function(responseObject, status, headers, config) { // error
+                var headersPretty = headers();
+                headersPretty.data = config.data;
 
-                $scope.response = {status_code: status, headers: headers_pretty, config: config};
-                $scope.response_object = response_object;
+                $scope.response = {statusCode: status, headers: headersPretty, config: config};
+                $scope.responseObject = responseObject;
                 $scope.$emit('App:displayContentLoaded', false);
             });
         },

--- a/src/flask_jsonrpc/contrib/browse/templates/browse/index.html
+++ b/src/flask_jsonrpc/contrib/browse/templates/browse/index.html
@@ -30,7 +30,7 @@
       <div class="row">
         <div id="logo-section">
           <div id="logo-loading-box"><div id="logo-loading" ng-show="showSpinner()"></div></div>
-          <a id="logo-link" class="title" href="#/">Web browsable API</a>
+          <a id="logo-link" class="title" href="#/" ng-click="goToDashboard()">Web browsable API</a>
         </div>
       </div>
       <div id="box-subscribe" class="row box-subscribe">
@@ -38,14 +38,14 @@
       </div>
       <div id="scrollable-sections">
         <ul class="nav nav-tabs nav-stacked">
-          <li><a id="logo-link" href="#/" ng-class="{active:routeIs('/')}"><i class="icon icon-home"></i> Dashboard</a></li>
+          <li><a id="logo-link" href="#/" ng-click="goToDashboard()" ng-class="{active:routeIs('/')}"><i class="icon icon-home"></i> Dashboard</a></li>
           {% raw %}
-          <li class="dropdown" ng-repeat="(package_name, modules) in packages">
-            <a data-toggle="collapse" data-target="#{{package_name}}"><i class="icon icon-folder-open"></i> {{package_name}}</a>
-            <div id="{{package_name}}" class="accordion-body collapse" ng-class="{in:$first}">
+          <li class="dropdown" ng-repeat="(packageName, modules) in packages">
+            <a data-toggle="collapse" data-target="#{{packageName}}"><i class="icon icon-folder-open"></i> {{packageName}}</a>
+            <div id="{{packageName}}" class="accordion-body collapse" ng-class="{in:$first}">
               <ul class="dropdown-submenu">
                 <li ng-repeat="module in modules">
-                  <a ng-click="showReponseObject(module)" ng-class="{active:routeIs(module.name)}" class="disableable" data-placement="bottom" data-toggle="tooltip" tooltip="{{showTooltip(module)}}"><i class="icon icon-caret-right"></i> {{module.name}}</a>
+                  <a ng-click="showResponseObject(module)" ng-class="{active:routeIs(module.name)}" class="disableable" data-placement="bottom" data-toggle="tooltip" tooltip="{{showTooltip(module)}}"><i class="icon icon-caret-right"></i> {{module.name}}</a>
                 </li>
               </ul>
             </div>
@@ -72,7 +72,7 @@
                   <li>
                     <h4 class="blue"><button ng-click="changeParameters()" class="btn btn-green">Change parameters</button></h4>
                   </li>
-                  <li>
+                  <li ng-show="showToolbarNotifyButton">
                     <h4 class="green"><button ng-click="notify()" class="btn btn-gold">Notify</button></h4>
                   </li>
                 </ul>

--- a/src/flask_jsonrpc/contrib/browse/templates/browse/partials/dashboard.html
+++ b/src/flask_jsonrpc/contrib/browse/templates/browse/partials/dashboard.html
@@ -9,8 +9,8 @@
     </div>
     <p><b>Response:</b></p>
     <div class="response-info">
-        <pre class="prettyprint"><div class="meta nocode"><b>HTTP {{ response.status_code }}</b></div>
-<span ng-bind-html="response_object|json|prettyprint"></span></pre>
+        <pre class="prettyprint"><div class="meta nocode"><b>HTTP {{ response.statusCode }}</b></div>
+<span ng-bind-html="responseObject|json|prettyprint"></span></pre>
     </div>
 </div>
 {% endraw %}

--- a/src/flask_jsonrpc/contrib/browse/templates/browse/partials/response_object.html
+++ b/src/flask_jsonrpc/contrib/browse/templates/browse/partials/response_object.html
@@ -14,7 +14,9 @@
               <label class="control-label" for="course">{{param.name}} -> {{param.type}}: </label><input type="text" class="form-control" name="{{param.name}}" id="{{param.name}}" ng-model="param.value" ng-keyup="hitEnter($event)" required>
               <span class="help-block"></span>
             </span>
-            <label class="control-label" for="notify">Is a notify?</label><input type="checkbox" class="form-control" name="notify" id="notify" ng-model="module.notify" />
+            <span ng-show="module.options.notification">
+              <label class="control-label" for="notify">Is a notify?</label><input type="checkbox" class="form-control" name="notify" id="notify" ng-model="module.notify" />
+            </span>
           </div>
         </ng-form>
       </div>
@@ -36,12 +38,12 @@
       <p><b>Request:</b></p>
       <div class="request-info" style="clear: both">
           <pre class="prettyprint"><b>{{ response.config.method }}</b> {{ response.config.url }}
-<span ng-bind-html="request_object|json|prettyprint"></span></pre>
+<span ng-bind-html="requestObject|json|prettyprint"></span></pre>
       </div>
       <p><b>Response:</b></p>
       <div class="response-info">
-          <pre class="prettyprint"><div class="meta nocode"><b>HTTP {{ response.status_code }}{{ response.status }}</b>
-<span ng-bind-html="response_object|json|prettyprint"></span></div></pre>
+          <pre class="prettyprint"><div class="meta nocode"><b>HTTP {{ response.statusCode }}{{ response.status }}</b>
+<span ng-bind-html="responseObject|json|prettyprint"></span></div></pre>
       </div>
   </span>
 </div>

--- a/src/flask_jsonrpc/settings.py
+++ b/src/flask_jsonrpc/settings.py
@@ -1,0 +1,51 @@
+# Copyright (c) 2023-2023, Cenobit Technologies, Inc. http://cenobit.es/
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# * Redistributions of source code must retain the above copyright notice,
+#    this list of conditions and the following disclaimer.
+# * Redistributions in binary form must reproduce the above copyright notice,
+#    this list of conditions and the following disclaimer in the documentation
+#    and/or other materials provided with the distribution.
+# * Neither the name of the Cenobit Technologies nor the names of
+#    its contributors may be used to endorse or promote products derived from
+#    this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+import typing as t
+
+DEFAULTS = {
+    'DEFAULT_JSONRPC_METHOD': {
+        'VALIDATE': True,
+        'NOTIFICATION': True,
+    },
+}
+
+
+class JSONRPCSettings:
+    def __init__(self, defaults: t.Optional[t.Dict[str, t.Any]] = None):
+        self.defaults = defaults or DEFAULTS
+
+    def __getattr__(self, attr: str) -> t.Any:
+        if attr not in self.defaults:
+            raise AttributeError(f"Invalid setting: '{attr}'")
+
+        val = self.defaults[attr]
+
+        setattr(self, attr, val)
+        return val
+
+
+settings = JSONRPCSettings(DEFAULTS)

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -64,6 +64,11 @@ def test_app_create():
     def fn3(s: str) -> str:
         return f'Foo {s}'
 
+    # pylint: disable=W0612
+    @jsonrpc.method('app.fn4', notification=False)
+    def fn4(s: str) -> str:
+        return f'Goo {s}'
+
     jsonrpc.register(fn3, name='app.fn3')
 
     with app.test_client() as client:
@@ -86,6 +91,26 @@ def test_app_create():
         rv = client.post('/api', json={'id': 1, 'jsonrpc': '2.0', 'method': 'app.fn3', 'params': [':)']})
         assert rv.json == {'id': 1, 'jsonrpc': '2.0', 'result': 'Foo :)'}
         assert rv.status_code == 200
+
+        rv = client.post('/api', json={'id': 1, 'jsonrpc': '2.0', 'method': 'app.fn4', 'params': [':)']})
+        assert rv.json == {'id': 1, 'jsonrpc': '2.0', 'result': 'Goo :)'}
+        assert rv.status_code == 200
+
+        rv = client.post('/api', json={'jsonrpc': '2.0', 'method': 'app.fn4', 'params': [':)']})
+        assert rv.json == {
+            'error': {
+                'code': -32600,
+                'data': {
+                    'message': "The method 'app.fn4' doesn't allow Notification Request "
+                    "object (without an 'id' member)"
+                },
+                'message': 'Invalid Request',
+                'name': 'InvalidRequestError',
+            },
+            'id': None,
+            'jsonrpc': '2.0',
+        }
+        assert rv.status_code == 400
 
         rv = client.post(
             '/api',

--- a/tests/test_apps/app/__init__.py
+++ b/tests/test_apps/app/__init__.py
@@ -62,6 +62,9 @@ class App:
     def notify(self, _string: str = None) -> None:
         pass
 
+    def not_allow_notify(self, _string: str = None) -> str:
+        return 'Now allow notify'
+
     def fails(self, n: int) -> int:
         if n % 2 == 0:
             return n
@@ -99,6 +102,11 @@ def create_app(test_config=None):  # noqa: C901  pylint: disable=W0612
     @jsonrpc.method('jsonrpc.notify')
     def notify(_string: str = None) -> None:
         pass
+
+    # pylint: disable=W0612
+    @jsonrpc.method('jsonrpc.not_allow_notify', notification=False)
+    def not_allow_notify(_string: str = None) -> str:
+        return 'Not allow notify'
 
     # pylint: disable=W0612
     @jsonrpc.method('jsonrpc.fails')
@@ -146,6 +154,7 @@ def create_app(test_config=None):  # noqa: C901  pylint: disable=W0612
     jsonrpc.register(class_app.hello)
     jsonrpc.register(class_app.echo)
     jsonrpc.register(class_app.notify)
+    jsonrpc.register(class_app.not_allow_notify, notification=False)
     jsonrpc.register(class_app.fails)
 
     return flask_app

--- a/tests/test_apps/async_app/__init__.py
+++ b/tests/test_apps/async_app/__init__.py
@@ -62,6 +62,9 @@ class App:
     def notify(self, _string: str = None) -> None:
         pass
 
+    def not_allow_notify(self, _string: str = None) -> str:
+        return 'Now allow notify'
+
     def fails(self, n: int) -> int:
         if n % 2 == 0:
             return n
@@ -101,6 +104,12 @@ def create_async_app(test_config=None):  # noqa: C901  pylint: disable=W0612
     @jsonrpc.method('jsonrpc.notify')
     async def notify(_string: str = None) -> None:
         await asyncio.sleep(0)
+
+    # pylint: disable=W0612
+    @jsonrpc.method('jsonrpc.not_allow_notify', notification=False)
+    async def not_allow_notify(_string: str = None) -> str:
+        await asyncio.sleep(0)
+        return 'Not allow notify'
 
     # pylint: disable=W0612
     @jsonrpc.method('jsonrpc.fails')
@@ -155,6 +164,7 @@ def create_async_app(test_config=None):  # noqa: C901  pylint: disable=W0612
     jsonrpc.register(class_app.hello)
     jsonrpc.register(class_app.echo)
     jsonrpc.register(class_app.notify)
+    jsonrpc.register(class_app.not_allow_notify, notification=False)
     jsonrpc.register(class_app.fails)
 
     return flask_app

--- a/tests/test_async_client.py
+++ b/tests/test_async_client.py
@@ -285,6 +285,30 @@ def test_app_notify(async_client):
     assert rv.status_code == 204
 
 
+def test_app_not_allow_notify(client):
+    rv = client.post('/api', json={'jsonrpc': '2.0', 'method': 'jsonrpc.not_allow_notify'})
+    assert rv.json == {
+        'error': {
+            'code': -32600,
+            'data': {
+                'message': "The method 'jsonrpc.not_allow_notify' doesn't allow Notification Request "
+                "object (without an 'id' member)"
+            },
+            'message': 'Invalid Request',
+            'name': 'InvalidRequestError',
+        },
+        'id': None,
+        'jsonrpc': '2.0',
+    }
+    assert rv.status_code == 400
+
+    rv = client.post(
+        '/api', json={'id': 1, 'jsonrpc': '2.0', 'method': 'jsonrpc.not_allow_notify', 'params': ['Some string']}
+    )
+    assert rv.json == {'id': 1, 'jsonrpc': '2.0', 'result': 'Not allow notify'}
+    assert rv.status_code == 200
+
+
 def test_app_fails(async_client):
     rv = async_client.post('/api', json={'id': 1, 'jsonrpc': '2.0', 'method': 'jsonrpc.fails', 'params': [2]})
     assert rv.json == {'id': 1, 'jsonrpc': '2.0', 'result': 2}
@@ -466,30 +490,42 @@ def test_app_system_describe(async_client):
     assert rv.json['result']['procs'] == [
         {
             'name': 'jsonrpc.greeting',
+            'options': {'notification': True, 'validate': True},
             'params': [{'name': 'name', 'type': 'String'}],
             'return': {'type': 'String'},
             'summary': None,
         },
         {
             'name': 'jsonrpc.echo',
+            'options': {'notification': True, 'validate': True},
             'params': [{'name': 'string', 'type': 'String'}, {'name': '_some', 'type': 'Object'}],
             'return': {'type': 'String'},
             'summary': None,
         },
         {
             'name': 'jsonrpc.notify',
+            'options': {'notification': True, 'validate': True},
             'params': [{'name': '_string', 'type': 'String'}],
             'return': {'type': 'Null'},
             'summary': None,
         },
         {
+            'name': 'jsonrpc.not_allow_notify',
+            'options': {'notification': False, 'validate': True},
+            'params': [{'name': '_string', 'type': 'String'}],
+            'return': {'type': 'String'},
+            'summary': None,
+        },
+        {
             'name': 'jsonrpc.fails',
+            'options': {'notification': True, 'validate': True},
             'params': [{'name': 'n', 'type': 'Number'}],
             'return': {'type': 'Number'},
             'summary': None,
         },
         {
             'name': 'jsonrpc.strangeEcho',
+            'options': {'notification': True, 'validate': True},
             'params': [
                 {'name': 'string', 'type': 'String'},
                 {'name': 'omg', 'type': 'Object'},
@@ -502,65 +538,88 @@ def test_app_system_describe(async_client):
         },
         {
             'name': 'jsonrpc.sum',
+            'options': {'notification': True, 'validate': True},
             'params': [{'name': 'a', 'type': 'Number'}, {'name': 'b', 'type': 'Number'}],
             'return': {'type': 'Number'},
             'summary': None,
         },
         {
             'name': 'jsonrpc.decorators',
+            'options': {'notification': True, 'validate': True},
             'params': [{'name': 'string', 'type': 'String'}],
             'return': {'type': 'String'},
             'summary': None,
         },
         {
             'name': 'jsonrpc.returnStatusCode',
+            'options': {'notification': True, 'validate': True},
             'params': [{'name': 's', 'type': 'String'}],
             'return': {'type': 'Array'},
             'summary': None,
         },
         {
             'name': 'jsonrpc.returnHeaders',
+            'options': {'notification': True, 'validate': True},
             'params': [{'name': 's', 'type': 'String'}],
             'return': {'type': 'Array'},
             'summary': None,
         },
         {
             'name': 'jsonrpc.returnStatusCodeAndHeaders',
+            'options': {'notification': True, 'validate': True},
             'params': [{'name': 's', 'type': 'String'}],
             'return': {'type': 'Array'},
             'summary': None,
         },
         {
             'name': 'classapp.index',
+            'options': {'notification': True, 'validate': True},
             'params': [{'name': 'name', 'type': 'String'}],
             'return': {'type': 'String'},
             'summary': None,
         },
         {
             'name': 'greeting',
+            'options': {'notification': True, 'validate': True},
             'params': [{'name': 'name', 'type': 'String'}],
             'return': {'type': 'String'},
             'summary': None,
         },
         {
             'name': 'hello',
+            'options': {'notification': True, 'validate': True},
             'params': [{'name': 'name', 'type': 'String'}],
             'return': {'type': 'String'},
             'summary': None,
         },
         {
             'name': 'echo',
+            'options': {'notification': True, 'validate': True},
             'params': [{'name': 'string', 'type': 'String'}, {'name': '_some', 'type': 'Object'}],
             'return': {'type': 'String'},
             'summary': None,
         },
         {
             'name': 'notify',
+            'options': {'notification': True, 'validate': True},
             'params': [{'name': '_string', 'type': 'String'}],
             'return': {'type': 'Null'},
             'summary': None,
         },
-        {'name': 'fails', 'params': [{'name': 'n', 'type': 'Number'}], 'return': {'type': 'Number'}, 'summary': None},
+        {
+            'name': 'not_allow_notify',
+            'options': {'notification': False, 'validate': True},
+            'params': [{'name': '_string', 'type': 'String'}],
+            'return': {'type': 'String'},
+            'summary': None,
+        },
+        {
+            'name': 'fails',
+            'options': {'notification': True, 'validate': True},
+            'params': [{'name': 'n', 'type': 'Number'}],
+            'return': {'type': 'Number'},
+            'summary': None,
+        },
     ]
 
     assert rv.status_code == 200

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -275,6 +275,30 @@ def test_app_notify(client):
     assert rv.status_code == 204
 
 
+def test_app_not_allow_notify(client):
+    rv = client.post('/api', json={'jsonrpc': '2.0', 'method': 'jsonrpc.not_allow_notify'})
+    assert rv.json == {
+        'error': {
+            'code': -32600,
+            'data': {
+                'message': "The method 'jsonrpc.not_allow_notify' doesn't allow Notification Request "
+                "object (without an 'id' member)"
+            },
+            'message': 'Invalid Request',
+            'name': 'InvalidRequestError',
+        },
+        'id': None,
+        'jsonrpc': '2.0',
+    }
+    assert rv.status_code == 400
+
+    rv = client.post(
+        '/api', json={'id': 1, 'jsonrpc': '2.0', 'method': 'jsonrpc.not_allow_notify', 'params': ['Some string']}
+    )
+    assert rv.json == {'id': 1, 'jsonrpc': '2.0', 'result': 'Not allow notify'}
+    assert rv.status_code == 200
+
+
 def test_app_fails(client):
     rv = client.post('/api', json={'id': 1, 'jsonrpc': '2.0', 'method': 'jsonrpc.fails', 'params': [2]})
     assert rv.json == {'id': 1, 'jsonrpc': '2.0', 'result': 2}
@@ -452,30 +476,42 @@ def test_app_system_describe(client):
     assert rv.json['result']['procs'] == [
         {
             'name': 'jsonrpc.greeting',
+            'options': {'notification': True, 'validate': True},
             'params': [{'name': 'name', 'type': 'String'}],
             'return': {'type': 'String'},
             'summary': None,
         },
         {
             'name': 'jsonrpc.echo',
+            'options': {'notification': True, 'validate': True},
             'params': [{'name': 'string', 'type': 'String'}, {'name': '_some', 'type': 'Object'}],
             'return': {'type': 'String'},
             'summary': None,
         },
         {
             'name': 'jsonrpc.notify',
+            'options': {'notification': True, 'validate': True},
             'params': [{'name': '_string', 'type': 'String'}],
             'return': {'type': 'Null'},
             'summary': None,
         },
         {
+            'name': 'jsonrpc.not_allow_notify',
+            'options': {'notification': False, 'validate': True},
+            'params': [{'name': '_string', 'type': 'String'}],
+            'return': {'type': 'String'},
+            'summary': None,
+        },
+        {
             'name': 'jsonrpc.fails',
+            'options': {'notification': True, 'validate': True},
             'params': [{'name': 'n', 'type': 'Number'}],
             'return': {'type': 'Number'},
             'summary': None,
         },
         {
             'name': 'jsonrpc.strangeEcho',
+            'options': {'notification': True, 'validate': True},
             'params': [
                 {'name': 'string', 'type': 'String'},
                 {'name': 'omg', 'type': 'Object'},
@@ -488,65 +524,88 @@ def test_app_system_describe(client):
         },
         {
             'name': 'jsonrpc.sum',
+            'options': {'notification': True, 'validate': True},
             'params': [{'name': 'a', 'type': 'Number'}, {'name': 'b', 'type': 'Number'}],
             'return': {'type': 'Number'},
             'summary': None,
         },
         {
             'name': 'jsonrpc.decorators',
+            'options': {'notification': True, 'validate': True},
             'params': [{'name': 'string', 'type': 'String'}],
             'return': {'type': 'String'},
             'summary': None,
         },
         {
             'name': 'jsonrpc.returnStatusCode',
+            'options': {'notification': True, 'validate': True},
             'params': [{'name': 's', 'type': 'String'}],
             'return': {'type': 'Array'},
             'summary': None,
         },
         {
             'name': 'jsonrpc.returnHeaders',
+            'options': {'notification': True, 'validate': True},
             'params': [{'name': 's', 'type': 'String'}],
             'return': {'type': 'Array'},
             'summary': None,
         },
         {
             'name': 'jsonrpc.returnStatusCodeAndHeaders',
+            'options': {'notification': True, 'validate': True},
             'params': [{'name': 's', 'type': 'String'}],
             'return': {'type': 'Array'},
             'summary': None,
         },
         {
             'name': 'classapp.index',
+            'options': {'notification': True, 'validate': True},
             'params': [{'name': 'name', 'type': 'String'}],
             'return': {'type': 'String'},
             'summary': None,
         },
         {
             'name': 'greeting',
+            'options': {'notification': True, 'validate': True},
             'params': [{'name': 'name', 'type': 'String'}],
             'return': {'type': 'String'},
             'summary': None,
         },
         {
             'name': 'hello',
+            'options': {'notification': True, 'validate': True},
             'params': [{'name': 'name', 'type': 'String'}],
             'return': {'type': 'String'},
             'summary': None,
         },
         {
             'name': 'echo',
+            'options': {'notification': True, 'validate': True},
             'params': [{'name': 'string', 'type': 'String'}, {'name': '_some', 'type': 'Object'}],
             'return': {'type': 'String'},
             'summary': None,
         },
         {
             'name': 'notify',
+            'options': {'notification': True, 'validate': True},
             'params': [{'name': '_string', 'type': 'String'}],
             'return': {'type': 'Null'},
             'summary': None,
         },
-        {'name': 'fails', 'params': [{'name': 'n', 'type': 'Number'}], 'return': {'type': 'Number'}, 'summary': None},
+        {
+            'name': 'not_allow_notify',
+            'options': {'notification': False, 'validate': True},
+            'params': [{'name': '_string', 'type': 'String'}],
+            'return': {'type': 'String'},
+            'summary': None,
+        },
+        {
+            'name': 'fails',
+            'options': {'notification': True, 'validate': True},
+            'params': [{'name': 'n', 'type': 'Number'}],
+            'return': {'type': 'Number'},
+            'summary': None,
+        },
     ]
 
     assert rv.status_code == 200


### PR DESCRIPTION
A Notification is a Request object without an "id" member. A Request object that is a Notification signifies the Client's lack of interest in the corresponding Response object, and as such, no Response object needs to be returned to the client. The Server MUST NOT reply to a Notification, including those that are within a batch request.

The new parameter allows defining whether the method will support the Notification Response object, the default is true. The use of this parameter is:

```
@jsonrpc.method('App.method', notification: bool = True)
```

When the `notification` parameter is false, the method itself doesn't allow the Notification Response object, in the other word, if the client calls the method with a Notification Request object the server will respond with an Error object with code = -32600 and message = Invalid Request.

Resolves: #369
