### PR TITLE
Fix func annotations by signarure

### DIFF
--- a/examples/wba/minimal.py
+++ b/examples/wba/minimal.py
@@ -81,5 +81,20 @@ def fails(_string: Optional[str]) -> NoReturn:
     raise ValueError('example of fail')
 
 
+@jsonrpc.method('App.notValidate', validate=False)
+def not_validate(s='Oops!'):  # noqa: ANN001,ANN202,ANN201
+    return f'Not validate: {s}'
+
+
+@jsonrpc.method('App.mixinNotValidate', validate=False)
+def mixin_not_validate(s, t: int, u, v: str, x, z):  # noqa: ANN001,ANN202,ANN201
+    return f'Not validate: {s} {t} {u} {v} {x} {z}'
+
+
+@jsonrpc.method('App.mixinNotValidateReturn', validate=False)
+def mixin_not_validate_with_no_return(_s, _t: int, _u, _v: str, _x, _z):  # noqa: ANN001,ANN202,ANN201
+    pass
+
+
 if __name__ == '__main__':
     app.run(host='0.0.0.0', debug=True)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ backend-path = ["src/buildtools"]
 
 [project]
 name = "Flask-JSONRPC"
-version = "3.0.1"
+version = "4.0.0a0"
 description = "Adds JSONRPC support to Flask."
 readme = {file = "README.md", content-type = "text/markdown"}
 license = {file = "LICENSE"}

--- a/src/flask_jsonrpc/contrib/browse/static/js/apps/browse/services.js
+++ b/src/flask_jsonrpc/contrib/browse/static/js/apps/browse/services.js
@@ -81,7 +81,12 @@
                     }
 
                     if (param.type === 'Object') {
-                        return eval('('+ param.value + ')');
+                        try {
+                            return eval('('+ param.value + ')');
+                        } catch (e) {
+                            console.error('Failed to evaluate the object:', param.value);
+                            return param.value;
+                        }
                     } else if (param.type === 'Number') {
                         if (param.value.indexOf('.') !== -1) {
                             return parseFloat(param.value);

--- a/tests/integration/test_app.py
+++ b/tests/integration/test_app.py
@@ -455,6 +455,31 @@ class APITest(APITestCase):
         self.assertEqual({'id': 1, 'jsonrpc': '2.0', 'result': 'Not validate: OK'}, rv.json())
         self.assertEqual(200, rv.status_code)
 
+    def test_mixin_not_validate_method(self: Self) -> None:
+        rv = self.requests.post(
+            API_URL,
+            json={
+                'id': 1,
+                'jsonrpc': '2.0',
+                'method': 'jsonrpc.mixin_not_validate',
+                'params': [':)', 1, 3.2, ':D', [1, 2, 3], {1: 1}],
+            },
+        )
+        self.assertEqual({'id': 1, 'jsonrpc': '2.0', 'result': 'Not validate: :) 1 3.2 :D [1, 2, 3] {1: 1}'}, rv.json())
+        self.assertEqual(200, rv.status_code)
+
+        rv = self.requests.post(
+            API_URL,
+            json={
+                'id': 1,
+                'jsonrpc': '2.0',
+                'method': 'jsonrpc.mixin_not_validate',
+                'params': {'s': ':)', 't': 1, 'u': 3.2, 'v': ':D', 'x': [1, 2, 3], 'z': {1: 1}},
+            },
+        )
+        self.assertEqual({'id': 1, 'jsonrpc': '2.0', 'result': 'Not validate: :) 1 3.2 :D [1, 2, 3] {1: 1}'}, rv.json())
+        self.assertEqual(200, rv.status_code)
+
     def test_no_return_method(self: Self) -> None:
         rv = self.requests.post(API_URL, json={'id': 1, 'jsonrpc': '2.0', 'method': 'jsonrpc.noReturn', 'params': []})
         self.assertEqual(
@@ -668,8 +693,22 @@ class APITest(APITestCase):
                 'jsonrpc.not_validate': {
                     'type': 'method',
                     'options': {'notification': True, 'validate': False},
-                    'params': [],
-                    'returns': {'type': 'Null'},
+                    'params': [{'name': 's', 'nullable': False, 'required': False, 'type': 'Object'}],
+                    'returns': {'type': 'Object'},
+                    'description': None,
+                },
+                'jsonrpc.mixin_not_validate': {
+                    'type': 'method',
+                    'options': {'notification': True, 'validate': False},
+                    'params': [
+                        {'name': 's', 'type': 'Object', 'required': False, 'nullable': False},
+                        {'name': 't', 'type': 'Number', 'required': False, 'nullable': False},
+                        {'name': 'u', 'type': 'Object', 'required': False, 'nullable': False},
+                        {'name': 'v', 'type': 'String', 'required': False, 'nullable': False},
+                        {'name': 'x', 'type': 'Object', 'required': False, 'nullable': False},
+                        {'name': 'z', 'type': 'Object', 'required': False, 'nullable': False},
+                    ],
+                    'returns': {'type': 'Object'},
                     'description': None,
                 },
                 'jsonrpc.noReturn': {

--- a/tests/test_apps/app/__init__.py
+++ b/tests/test_apps/app/__init__.py
@@ -158,6 +158,11 @@ def create_app(test_config: t.Dict[str, t.Any] = None) -> Flask:  # noqa: C901  
     def not_validate(s='Oops!'):  # noqa: ANN001,ANN202
         return f'Not validate: {s}'
 
+    # pylint: disable=W0612
+    @jsonrpc.method('jsonrpc.mixin_not_validate', validate=False)
+    def mixin_not_validate(s, t: int, u, v: str, x, z):  # noqa: ANN001,ANN202
+        return f'Not validate: {s} {t} {u} {v} {x} {z}'
+
     @jsonrpc.method('jsonrpc.noReturn')
     def no_return(_string: t.Optional[str] = None) -> t.NoReturn:
         raise ValueError('no return')

--- a/tests/test_apps/async_app/__init__.py
+++ b/tests/test_apps/async_app/__init__.py
@@ -176,6 +176,12 @@ def create_async_app(test_config: t.Dict[str, t.Any] = None) -> Flask:  # noqa: 
         await asyncio.sleep(0)
         return f'Not validate: {s}'
 
+    # pylint: disable=W0612
+    @jsonrpc.method('jsonrpc.mixin_not_validate', validate=False)
+    async def mixin_not_validate(s, t: int, u, v: str, x, z):  # noqa: ANN001,ANN202
+        await asyncio.sleep(0)
+        return f'Not validate: {s} {t} {u} {v} {x} {z}'
+
     @jsonrpc.method('jsonrpc.noReturn')
     async def no_return(_string: t.Optional[str] = None) -> t.NoReturn:
         await asyncio.sleep(0)

--- a/tests/unit/test_async_client.py
+++ b/tests/unit/test_async_client.py
@@ -593,8 +593,22 @@ def test_app_system_describe(async_client: 'FlaskClient') -> None:
         'jsonrpc.not_validate': {
             'type': 'method',
             'options': {'notification': True, 'validate': False},
-            'params': [],
-            'returns': {'type': 'Null'},
+            'params': [{'name': 's', 'nullable': False, 'required': False, 'type': 'Object'}],
+            'returns': {'type': 'Object'},
+            'description': None,
+        },
+        'jsonrpc.mixin_not_validate': {
+            'type': 'method',
+            'options': {'notification': True, 'validate': False},
+            'params': [
+                {'name': 's', 'type': 'Object', 'required': False, 'nullable': False},
+                {'name': 't', 'type': 'Number', 'required': False, 'nullable': False},
+                {'name': 'u', 'type': 'Object', 'required': False, 'nullable': False},
+                {'name': 'v', 'type': 'String', 'required': False, 'nullable': False},
+                {'name': 'x', 'type': 'Object', 'required': False, 'nullable': False},
+                {'name': 'z', 'type': 'Object', 'required': False, 'nullable': False},
+            ],
+            'returns': {'type': 'Object'},
             'description': None,
         },
         'jsonrpc.noReturn': {

--- a/tests/unit/test_client.py
+++ b/tests/unit/test_client.py
@@ -581,8 +581,22 @@ def test_app_system_describe(client: 'FlaskClient') -> None:
         'jsonrpc.not_validate': {
             'type': 'method',
             'options': {'notification': True, 'validate': False},
-            'params': [],
-            'returns': {'type': 'Null'},
+            'params': [{'name': 's', 'nullable': False, 'required': False, 'type': 'Object'}],
+            'returns': {'type': 'Object'},
+            'description': None,
+        },
+        'jsonrpc.mixin_not_validate': {
+            'type': 'method',
+            'options': {'notification': True, 'validate': False},
+            'params': [
+                {'name': 's', 'type': 'Object', 'required': False, 'nullable': False},
+                {'name': 't', 'type': 'Number', 'required': False, 'nullable': False},
+                {'name': 'u', 'type': 'Object', 'required': False, 'nullable': False},
+                {'name': 'v', 'type': 'String', 'required': False, 'nullable': False},
+                {'name': 'x', 'type': 'Object', 'required': False, 'nullable': False},
+                {'name': 'z', 'type': 'Object', 'required': False, 'nullable': False},
+            ],
+            'returns': {'type': 'Object'},
             'description': None,
         },
         'jsonrpc.noReturn': {


### PR DESCRIPTION
It allows to have a function without either complete type validation or only partial type 
validation, also it enables these kinds of parameters/functions to have support on Browse API.

Notice, the function without the type validation option setting equal true, the return type of 
the function always will be the `typing.Any` if the type annotation is not set on the function.

Solve #387

<!--
## The seven rules of a great Git commit message

:: Keep in mind: This has all been said before.

1. Separate subject from body with a blank line
2. Limit the subject line to 50 characters
3. Capitalize the subject line
4. Do not end the subject line with a period
5. Use the imperative mood in the subject line
6. Wrap the body at 72 characters
7. Use the body to explain what and why vs. how

For example:

```
Summarize changes in around 50 characters or less

More detailed explanatory text, if necessary. Wrap it to about 72
characters or so. In some contexts, the first line is treated as the
subject of the commit and the rest of the text as the body. The
blank line separating the summary from the body is critical (unless
you omit the body entirely); various tools like `log`, `shortlog`
and `rebase` can get confused if you run the two together.

Explain the problem that this commit is solving. Focus on why you
are making this change as opposed to how (the code explains that).
Are there side effects or other unintuitive consequences of this
change? Here's the place to explain them.

Further paragraphs come after blank lines.

 - Bullet points are okay, too

 - Typically a hyphen or asterisk is used for the bullet, preceded
   by a single space, with blank lines in between, but conventions
   vary here

If you use an issue tracker, put references to them at the bottom,
like this:

Resolves: #123
See also: #456, #789
```

More details: https://chris.beams.io/posts/git-commit/.
-->