### PR TITLE
Make method description rendering consistent with popup

### DIFF
--- a/src/flask_jsonrpc/contrib/browse/static/css/bootstrap-browse.css
+++ b/src/flask_jsonrpc/contrib/browse/static/css/bootstrap-browse.css
@@ -391,6 +391,7 @@ body {
 #login-page.container {width:320px;}
 
 /* dashboard */
+.method-description {white-space: pre-wrap;}
 .summary {display:table; width:100%; padding:0; margin:0 0 20px 0;}
 .summary ul {margin:0; padding:0; overflow:hidden; display:table-row;}
 .summary li {margin:0; padding:19px; display:table-cell; border-right:1px solid #eee;}

--- a/src/flask_jsonrpc/contrib/browse/templates/browse/partials/response_object.html
+++ b/src/flask_jsonrpc/contrib/browse/templates/browse/partials/response_object.html
@@ -7,7 +7,7 @@
         <h4 class="modal-title"><span class="glyphicon glyphicon-star"></span> {{module.name}}(<span ng-repeat="param in module.params">{{param.name}}: {{param.type}}<span ng-if="!$last">, </span></span>) -> {{module.returns.type}}</h4>
       </div>
       <div class="modal-body">
-        <h5><b>Description:</b> <span ng-if="!module.description">None</span><span style="white-space: pre-wrap;">{{module.description}}</span></h5>
+        <h5><b>Description:</b> <span ng-if="!module.description">None</span><span class="method-description">{{module.description}}</span></h5>
         <ng-form name="nameDialog" novalidate role="form">
           <div class="form-group input-group-lg">
             <span ng-repeat="param in module.params">
@@ -33,7 +33,7 @@
 {% raw %}
 <div class="content-main">
     <div class="page-header"><h1>{{module.name}}(<span ng-repeat="param in module.params">{{param.name}}: {{param.type}}<span ng-if="!$last">, </span></span>) -> {{module.returns.type}}</h1></div>
-    <blockquote>{{ module.description }}</blockquote>
+    <blockquote class="method-description">{{ module.description }}</blockquote>
     <span >
       <p><b>Request:</b></p>
       <div class="request-info" style="clear: both">


### PR DESCRIPTION
Popup uses `style="white-space: pre-wrap;"` for description text which renders newlines, while method's page itself does not.

Allowing newlines is useful to make longer description more readable.