### PR TITLE
Add error handler to unexpected exception

### DIFF
--- a/examples/minimal/minimal.py
+++ b/examples/minimal/minimal.py
@@ -47,6 +47,15 @@ app = Flask('minimal')
 jsonrpc = JSONRPC(app, '/api', enable_web_browsable_api=True)
 
 
+class MyException(Exception):
+    pass
+
+
+@jsonrpc.errorhandler(MyException)
+def handle_my_exception(ex: MyException) -> t.Dict[str, t.Any]:
+    return {'message': 'It is a custom exception', 'code': '0001'}
+
+
 @jsonrpc.method('App.index')
 def index() -> str:
     return 'Welcome to Flask JSON-RPC'
@@ -80,6 +89,11 @@ def not_notify(string: str) -> str:
 @jsonrpc.method('App.fails')
 def fails(_string: t.Optional[str] = None) -> t.NoReturn:
     raise ValueError('example of fail')
+
+
+@jsonrpc.method('App.failsWithCustomException')
+def fails_with_custom_exception(_string: t.Optional[str] = None) -> t.NoReturn:
+    raise MyException('example of fail with custom exception that will be handled')
 
 
 @jsonrpc.method('App.sum')

--- a/examples/modular/api/user.py
+++ b/examples/modular/api/user.py
@@ -24,11 +24,51 @@
 # CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
 # ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
+import typing as t
+
 from flask_jsonrpc import JSONRPCBlueprint
 
 user = JSONRPCBlueprint('user', __name__)
 
 
+class UserException(Exception):
+    def __init__(self: t.Self, *args: object) -> None:
+        super().__init__(*args)
+
+
+class UserNotFoundException(UserException):
+    def __init__(self: t.Self, message: str, user_id: int) -> None:
+        super().__init__(message)
+        self.user_id = user_id
+
+
+class User:
+    def __init__(self: t.Self, id: int, name: str) -> None:
+        self.id = id
+        self.name = name
+
+
+def handle_user_not_found_exception(ex: UserNotFoundException) -> t.Dict[str, t.Any]:
+    return {'message': f'User {ex.user_id} not found', 'code': '1001'}
+
+
+user.register_error_handler(UserNotFoundException, handle_user_not_found_exception)
+
+
 @user.method('User.index')
 def index() -> str:
     return 'Welcome to User API'
+
+
+@user.method('User.getUser')
+def get_user(id: int) -> User:
+    if id > 10:
+        raise UserNotFoundException('User not found', user_id=id)
+    return User(id, 'Founded')
+
+
+@user.method('User.removeUser')
+def remove_user(id: int) -> User:
+    if id > 10:
+        raise ValueError('User not found')
+    return User(id, 'Removed')

--- a/examples/modular/modular.py
+++ b/examples/modular/modular.py
@@ -26,6 +26,7 @@
 # ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
 # isort:skip_file
+import typing as t
 import os
 import sys
 
@@ -48,6 +49,12 @@ app = Flask('modular')
 jsonrpc = JSONRPC(app, '/api', enable_web_browsable_api=True)
 jsonrpc.register_blueprint(app, user, url_prefix='/user', enable_web_browsable_api=True)
 jsonrpc.register_blueprint(app, article, url_prefix='/article', enable_web_browsable_api=True)
+
+jsonrpc.errorhandler(ValueError)
+
+
+def handle_value_error_exception(ex: ValueError) -> t.Dict[str, t.Any]:
+    return {'message': 'Generic global error handler does not work, :(', 'code': '0000'}
 
 
 @jsonrpc.method('App.index')

--- a/src/flask_jsonrpc/app.py
+++ b/src/flask_jsonrpc/app.py
@@ -31,6 +31,7 @@ from flask import Flask
 
 from .globals import default_jsonrpc_site, default_jsonrpc_site_api
 from .helpers import urn
+from .handlers import JSONRPCErrorHandlerDecoratorMixin
 from .wrappers import JSONRPCDecoratorMixin
 from .contrib.browse import JSONRPCBrowse
 
@@ -46,7 +47,7 @@ if t.TYPE_CHECKING:
     from .blueprints import JSONRPCBlueprint
 
 
-class JSONRPC(JSONRPCDecoratorMixin):
+class JSONRPC(JSONRPCDecoratorMixin, JSONRPCErrorHandlerDecoratorMixin):
     def __init__(
         self: Self,
         app: t.Optional[Flask] = None,
@@ -134,6 +135,9 @@ class JSONRPC(JSONRPCDecoratorMixin):
 
         if app.config['DEBUG'] or enable_web_browsable_api:
             self.register_browse(jsonrpc_app)
+
+    def register_error_handler(self: Self, exception: t.Type[Exception], fn: t.Callable[[t.Any], t.Any]) -> None:
+        super().register_error_handler(exception, fn)
 
     def init_browse_app(self: Self, app: Flask, path: t.Optional[str] = None, base_url: t.Optional[str] = None) -> None:
         browse_url = self._make_jsonrpc_browse_url(path or self.path)

--- a/src/flask_jsonrpc/blueprints.py
+++ b/src/flask_jsonrpc/blueprints.py
@@ -26,7 +26,10 @@
 # POSSIBILITY OF SUCH DAMAGE.
 import typing as t
 
+from flask import typing as ft
+
 from .globals import default_jsonrpc_site, default_jsonrpc_site_api
+from .handlers import JSONRPCErrorHandlerDecoratorMixin
 from .wrappers import JSONRPCDecoratorMixin
 
 # Python 3.10+
@@ -40,7 +43,7 @@ if t.TYPE_CHECKING:
     from .views import JSONRPCView
 
 
-class JSONRPCBlueprint(JSONRPCDecoratorMixin):
+class JSONRPCBlueprint(JSONRPCDecoratorMixin, JSONRPCErrorHandlerDecoratorMixin):
     def __init__(
         self: Self,
         name: str,
@@ -58,3 +61,6 @@ class JSONRPCBlueprint(JSONRPCDecoratorMixin):
 
     def get_jsonrpc_site_api(self: Self) -> t.Type['JSONRPCView']:
         return self.jsonrpc_site_api
+
+    def register_error_handler(self: Self, exception: t.Type[Exception], fn: ft.ErrorHandlerCallable) -> None:
+        super().register_error_handler(exception, fn)

--- a/src/flask_jsonrpc/exceptions.py
+++ b/src/flask_jsonrpc/exceptions.py
@@ -82,7 +82,6 @@ class JSONRPCError(Exception):
     @property
     def jsonrpc_format(self: Self) -> t.Dict[str, t.Any]:
         """Return the Exception data in a format for JSON-RPC"""
-
         error = {'name': self.__class__.__name__, 'code': self.code, 'message': self.message, 'data': self.data}
 
         # RuntimeError: Working outside of application context.

--- a/tests/integration/test_app.py
+++ b/tests/integration/test_app.py
@@ -597,7 +597,6 @@ class APITest(APITestCase):
                 'method': 'jsonrpc.createColor',
                 'params': {'color': {'name': 'Blue', 'tag': 'good'}},
             },
-            headers={'Content-Type': 'application/json'},
         )
         self.assertEqual(200, rv.status_code)
         self.assertDictEqual({'id': 1, 'jsonrpc': '2.0', 'result': {'id': 1, 'name': 'Blue', 'tag': 'good'}}, rv.json())
@@ -605,7 +604,6 @@ class APITest(APITestCase):
         rv = self.requests.post(
             API_URL,
             json={'id': 1, 'jsonrpc': '2.0', 'method': 'jsonrpc.createColor', 'params': {'color': {'name': 'Red'}}},
-            headers={'Content-Type': 'application/json'},
         )
         self.assertEqual(400, rv.status_code)
         data = rv.json()
@@ -624,7 +622,6 @@ class APITest(APITestCase):
                 'method': 'jsonrpc.createManyColor',
                 'params': {'colors': [{'name': 'Blue', 'tag': 'good'}, {'name': 'Red', 'tag': 'bad'}]},
             },
-            headers={'Content-Type': 'application/json'},
         )
         self.assertEqual(200, rv.status_code)
         self.assertDictEqual(
@@ -644,7 +641,6 @@ class APITest(APITestCase):
                 'method': 'jsonrpc.createManyColor',
                 'params': {'colors': [{'name': 'Blue', 'tag': 'good'}], 'color': {'name': 'Red', 'tag': 'bad'}},
             },
-            headers={'Content-Type': 'application/json'},
         )
         self.assertEqual(200, rv.status_code)
         self.assertDictEqual(
@@ -667,7 +663,6 @@ class APITest(APITestCase):
                     {'name': 'Green', 'tag': 'yay'},
                 ],
             },
-            headers={'Content-Type': 'application/json'},
         )
         self.assertEqual(200, rv.status_code)
         self.assertDictEqual(
@@ -691,7 +686,6 @@ class APITest(APITestCase):
                 'method': 'jsonrpc.createManyFixColor',
                 'params': {'colors': {'1': {'name': 'Blue', 'tag': 'good'}}},
             },
-            headers={'Content-Type': 'application/json'},
         )
         self.assertEqual(200, rv.status_code)
         self.assertDictEqual(
@@ -706,26 +700,45 @@ class APITest(APITestCase):
                 'method': 'jsonrpc.removeColor',
                 'params': {'color': {'id': 1, 'name': 'Blue', 'tag': 'good'}},
             },
-            headers={'Content-Type': 'application/json'},
         )
         self.assertEqual(200, rv.status_code)
         self.assertDictEqual({'id': 1, 'jsonrpc': '2.0', 'result': {'id': 1, 'name': 'Blue', 'tag': 'good'}}, rv.json())
 
         rv = self.requests.post(
-            API_URL,
-            json={'id': 1, 'jsonrpc': '2.0', 'method': 'jsonrpc.removeColor', 'params': {'color': None}},
-            headers={'Content-Type': 'application/json'},
+            API_URL, json={'id': 1, 'jsonrpc': '2.0', 'method': 'jsonrpc.removeColor', 'params': {'color': None}}
+        )
+        self.assertEqual(200, rv.status_code)
+        self.assertDictEqual({'id': 1, 'jsonrpc': '2.0', 'result': None}, rv.json())
+
+        rv = self.requests.post(
+            API_URL, json={'id': 1, 'jsonrpc': '2.0', 'method': 'jsonrpc.removeColor', 'params': []}
         )
         self.assertEqual(200, rv.status_code)
         self.assertDictEqual({'id': 1, 'jsonrpc': '2.0', 'result': None}, rv.json())
 
         rv = self.requests.post(
             API_URL,
-            json={'id': 1, 'jsonrpc': '2.0', 'method': 'jsonrpc.removeColor', 'params': []},
-            headers={'Content-Type': 'application/json'},
+            json={
+                'id': 1,
+                'jsonrpc': '2.0',
+                'method': 'jsonrpc.removeColor',
+                'params': {'color': {'id': 100, 'name': 'Blue', 'tag': 'good'}},
+            },
         )
-        self.assertEqual(200, rv.status_code)
-        self.assertDictEqual({'id': 1, 'jsonrpc': '2.0', 'result': None}, rv.json())
+        self.assertEqual(500, rv.status_code)
+        self.assertDictEqual(
+            {
+                'id': 1,
+                'jsonrpc': '2.0',
+                'error': {
+                    'code': -32000,
+                    'data': {'color_id': 100, 'reason': 'The color with an ID greater than 10 does not exist.'},
+                    'message': 'Server error',
+                    'name': 'ServerError',
+                },
+            },
+            rv.json(),
+        )
 
     def test_app_with_dataclass(self: Self) -> None:
         rv = self.requests.post(
@@ -736,7 +749,6 @@ class APITest(APITestCase):
                 'method': 'jsonrpc.createCar',
                 'params': {'car': {'name': 'Fusca', 'tag': 'blue'}},
             },
-            headers={'Content-Type': 'application/json'},
         )
         self.assertEqual(200, rv.status_code)
         self.assertDictEqual(
@@ -746,7 +758,6 @@ class APITest(APITestCase):
         rv = self.requests.post(
             API_URL,
             json={'id': 1, 'jsonrpc': '2.0', 'method': 'jsonrpc.createCar', 'params': {'car': {'name': 'Fusca'}}},
-            headers={'Content-Type': 'application/json'},
         )
         self.assertEqual(400, rv.status_code)
         data = rv.json()
@@ -765,7 +776,6 @@ class APITest(APITestCase):
                 'method': 'jsonrpc.createManyCar',
                 'params': {'cars': [{'name': 'Fusca', 'tag': 'blue'}, {'name': 'Kombi', 'tag': 'yellow'}]},
             },
-            headers={'Content-Type': 'application/json'},
         )
         self.assertEqual(200, rv.status_code)
         self.assertDictEqual(
@@ -785,7 +795,6 @@ class APITest(APITestCase):
                 'method': 'jsonrpc.createManyCar',
                 'params': {'cars': [{'name': 'Fusca', 'tag': 'blue'}], 'car': {'name': 'Kombi', 'tag': 'yellow'}},
             },
-            headers={'Content-Type': 'application/json'},
         )
         self.assertEqual(200, rv.status_code)
         self.assertDictEqual(
@@ -808,7 +817,6 @@ class APITest(APITestCase):
                     {'name': 'Gol', 'tag': 'white'},
                 ],
             },
-            headers={'Content-Type': 'application/json'},
         )
         self.assertEqual(200, rv.status_code)
         self.assertDictEqual(
@@ -832,7 +840,6 @@ class APITest(APITestCase):
                 'method': 'jsonrpc.createManyFixCar',
                 'params': {'cars': {'1': {'name': 'Fusca', 'tag': 'blue'}}},
             },
-            headers={'Content-Type': 'application/json'},
         )
         self.assertEqual(200, rv.status_code)
         self.assertDictEqual(
@@ -847,7 +854,6 @@ class APITest(APITestCase):
                 'method': 'jsonrpc.removeCar',
                 'params': {'car': {'id': 1, 'name': 'Fusca', 'tag': 'blue'}},
             },
-            headers={'Content-Type': 'application/json'},
         )
         self.assertEqual(200, rv.status_code)
         self.assertDictEqual(
@@ -855,20 +861,38 @@ class APITest(APITestCase):
         )
 
         rv = self.requests.post(
-            API_URL,
-            json={'id': 1, 'jsonrpc': '2.0', 'method': 'jsonrpc.removeCar', 'params': {'car': None}},
-            headers={'Content-Type': 'application/json'},
+            API_URL, json={'id': 1, 'jsonrpc': '2.0', 'method': 'jsonrpc.removeCar', 'params': {'car': None}}
         )
+        self.assertEqual(200, rv.status_code)
+        self.assertDictEqual({'id': 1, 'jsonrpc': '2.0', 'result': None}, rv.json())
+
+        rv = self.requests.post(API_URL, json={'id': 1, 'jsonrpc': '2.0', 'method': 'jsonrpc.removeCar', 'params': []})
         self.assertEqual(200, rv.status_code)
         self.assertDictEqual({'id': 1, 'jsonrpc': '2.0', 'result': None}, rv.json())
 
         rv = self.requests.post(
             API_URL,
-            json={'id': 1, 'jsonrpc': '2.0', 'method': 'jsonrpc.removeCar', 'params': []},
-            headers={'Content-Type': 'application/json'},
+            json={
+                'id': 1,
+                'jsonrpc': '2.0',
+                'method': 'jsonrpc.removeCar',
+                'params': {'car': {'id': 100, 'name': 'Fusca', 'tag': 'blue'}},
+            },
         )
-        self.assertEqual(200, rv.status_code)
-        self.assertDictEqual({'id': 1, 'jsonrpc': '2.0', 'result': None}, rv.json())
+        self.assertEqual(500, rv.status_code)
+        self.assertDictEqual(
+            {
+                'id': 1,
+                'jsonrpc': '2.0',
+                'error': {
+                    'code': -32000,
+                    'data': {'car_id': 100, 'reason': 'The car with an ID greater than 10 does not exist.'},
+                    'message': 'Server error',
+                    'name': 'ServerError',
+                },
+            },
+            rv.json(),
+        )
 
     def test_app_with_pydantic(self: Self) -> None:
         rv = self.requests.post(
@@ -879,15 +903,12 @@ class APITest(APITestCase):
                 'method': 'jsonrpc.createPet',
                 'params': {'pet': {'name': 'Eve', 'tag': 'dog'}},
             },
-            headers={'Content-Type': 'application/json'},
         )
         self.assertEqual(200, rv.status_code)
         self.assertDictEqual({'id': 1, 'jsonrpc': '2.0', 'result': {'id': 1, 'name': 'Eve', 'tag': 'dog'}}, rv.json())
 
         rv = self.requests.post(
-            API_URL,
-            json={'id': 1, 'jsonrpc': '2.0', 'method': 'jsonrpc.createPet', 'params': {'pet': {'name': 'Eve'}}},
-            headers={'Content-Type': 'application/json'},
+            API_URL, json={'id': 1, 'jsonrpc': '2.0', 'method': 'jsonrpc.createPet', 'params': {'pet': {'name': 'Eve'}}}
         )
         self.assertEqual(400, rv.status_code)
         self.assertDictEqual(
@@ -919,7 +940,6 @@ class APITest(APITestCase):
                 'method': 'jsonrpc.createManyPet',
                 'params': {'pets': [{'name': 'Eve', 'tag': 'dog'}, {'name': 'Lou', 'tag': 'dog'}]},
             },
-            headers={'Content-Type': 'application/json'},
         )
         self.assertEqual(200, rv.status_code)
         self.assertDictEqual(
@@ -939,7 +959,6 @@ class APITest(APITestCase):
                 'method': 'jsonrpc.createManyPet',
                 'params': {'pets': [{'name': 'Eve', 'tag': 'dog'}], 'pet': {'name': 'Lou', 'tag': 'dog'}},
             },
-            headers={'Content-Type': 'application/json'},
         )
         self.assertEqual(200, rv.status_code)
         self.assertDictEqual(
@@ -962,7 +981,6 @@ class APITest(APITestCase):
                     {'name': 'Tequila', 'tag': 'cat'},
                 ],
             },
-            headers={'Content-Type': 'application/json'},
         )
         self.assertEqual(200, rv.status_code)
         self.assertDictEqual(
@@ -986,7 +1004,6 @@ class APITest(APITestCase):
                 'method': 'jsonrpc.createManyFixPet',
                 'params': {'pets': {'1': {'name': 'Eve', 'tag': 'dog'}}},
             },
-            headers={'Content-Type': 'application/json'},
         )
         self.assertEqual(200, rv.status_code)
         self.assertDictEqual({'id': 1, 'jsonrpc': '2.0', 'result': [{'id': 1, 'name': 'Eve', 'tag': 'dog'}]}, rv.json())
@@ -1004,20 +1021,38 @@ class APITest(APITestCase):
         self.assertDictEqual({'id': 1, 'jsonrpc': '2.0', 'result': {'id': 1, 'name': 'Eve', 'tag': 'dog'}}, rv.json())
 
         rv = self.requests.post(
-            API_URL,
-            json={'id': 1, 'jsonrpc': '2.0', 'method': 'jsonrpc.removePet', 'params': {'pet': None}},
-            headers={'Content-Type': 'application/json'},
+            API_URL, json={'id': 1, 'jsonrpc': '2.0', 'method': 'jsonrpc.removePet', 'params': {'pet': None}}
         )
+        self.assertEqual(200, rv.status_code)
+        self.assertDictEqual({'id': 1, 'jsonrpc': '2.0', 'result': None}, rv.json())
+
+        rv = self.requests.post(API_URL, json={'id': 1, 'jsonrpc': '2.0', 'method': 'jsonrpc.removePet', 'params': []})
         self.assertEqual(200, rv.status_code)
         self.assertDictEqual({'id': 1, 'jsonrpc': '2.0', 'result': None}, rv.json())
 
         rv = self.requests.post(
             API_URL,
-            json={'id': 1, 'jsonrpc': '2.0', 'method': 'jsonrpc.removePet', 'params': []},
-            headers={'Content-Type': 'application/json'},
+            json={
+                'id': 1,
+                'jsonrpc': '2.0',
+                'method': 'jsonrpc.removePet',
+                'params': {'pet': {'id': 100, 'name': 'Lou', 'tag': 'dog'}},
+            },
         )
-        self.assertEqual(200, rv.status_code)
-        self.assertDictEqual({'id': 1, 'jsonrpc': '2.0', 'result': None}, rv.json())
+        self.assertEqual(500, rv.status_code)
+        self.assertDictEqual(
+            {
+                'id': 1,
+                'jsonrpc': '2.0',
+                'error': {
+                    'code': -32000,
+                    'data': {'pet_id': 100, 'reason': 'The pet with an ID greater than 10 does not exist.'},
+                    'message': 'Server error',
+                    'name': 'ServerError',
+                },
+            },
+            rv.json(),
+        )
 
     def test_system_describe(self: Self) -> None:
         rv = self.requests.post(API_URL, json={'id': 1, 'jsonrpc': '2.0', 'method': 'rpc.describe'})

--- a/tests/unit/test_async_app.py
+++ b/tests/unit/test_async_app.py
@@ -36,7 +36,20 @@ from werkzeug.datastructures import Headers
 
 from flask_jsonrpc import JSONRPC, JSONRPCBlueprint
 
+# Python 3.10+
+try:
+    from typing import Self
+except ImportError:  # pragma: no cover
+    from typing_extensions import Self
+
 pytest.importorskip('asgiref')
+
+
+class CustomException(Exception):
+    def __init__(self: Self, message: str, data: t.Dict[str, t.Any]) -> None:
+        super().__init__(message)
+        self.message = message
+        self.data = data
 
 
 def test_app_create() -> None:
@@ -73,7 +86,8 @@ def test_app_create() -> None:
 
     # pylint: disable=W0612
     @jsonrpc.method('app.fn4', notification=False)
-    def fn4(s: str) -> str:
+    async def fn4(s: str) -> str:
+        await asyncio.sleep(0)
         return f'Goo {s}'
 
     jsonrpc.register(fn3, name='app.fn3')
@@ -144,6 +158,126 @@ def test_app_create() -> None:
         assert rv.status_code == 200
 
 
+def test_app_create_using_error_handler() -> None:
+    app = Flask('test_app', instance_relative_config=True)
+    jsonrpc = JSONRPC(app, '/api', enable_web_browsable_api=True)
+
+    @jsonrpc.errorhandler(CustomException)
+    async def handle_custom_exc(exc: CustomException) -> t.Dict[str, t.Any]:
+        await asyncio.sleep(0)
+        return exc.data
+
+    # pylint: disable=W0612
+    @jsonrpc.method('app.index')
+    async def index() -> str:
+        await asyncio.sleep(0)
+        return 'Welcome to Flask JSON-RPC'
+
+    # pylint: disable=W0612
+    @jsonrpc.method('app.errorhandler')
+    async def fn0() -> t.NoReturn:
+        await asyncio.sleep(0)
+        raise CustomException('Testing error handler', data={'message': 'Flask JSON-RPC', 'code': '0000'})
+
+    with app.test_client() as client:
+        rv = client.post('/api', json={'id': 1, 'jsonrpc': '2.0', 'method': 'app.index', 'params': []})
+        assert rv.json == {'id': 1, 'jsonrpc': '2.0', 'result': 'Welcome to Flask JSON-RPC'}
+        assert rv.status_code == 200
+
+        rv = client.post('/api', json={'id': 1, 'jsonrpc': '2.0', 'method': 'app.errorhandler', 'params': []})
+        assert rv.json == {
+            'id': 1,
+            'jsonrpc': '2.0',
+            'error': {
+                'code': -32000,
+                'data': {'code': '0000', 'message': 'Flask JSON-RPC'},
+                'message': 'Server error',
+                'name': 'ServerError',
+            },
+        }
+        assert rv.status_code == 500
+
+
+def test_app_create_modular_using_error_handler() -> None:
+    jsonrpc_api_1 = JSONRPCBlueprint('jsonrpc_api_1', __name__)
+
+    @jsonrpc_api_1.errorhandler(CustomException)
+    async def handle_custom_exc_jsonrpc_api_1(exc: CustomException) -> t.Dict[str, t.Any]:
+        await asyncio.sleep(0)
+        return f"jsonrpc_api_1: {exc.data['message']}"
+
+    # pylint: disable=W0612
+    @jsonrpc_api_1.method('blue1.index')
+    async def index_b1() -> str:
+        await asyncio.sleep(0)
+        return 'b1 index'
+
+    # pylint: disable=W0612
+    @jsonrpc_api_1.method('blue1.errorhandler')
+    async def error_b1() -> t.NoReturn:
+        await asyncio.sleep(0)
+        raise CustomException('Testing error handler', data={'message': 'Flask JSON-RPC', 'code': '0000'})
+
+    jsonrpc_api_2 = JSONRPCBlueprint('jsonrpc_api_2', __name__)
+
+    @jsonrpc_api_2.errorhandler(CustomException)
+    async def handle_custom_exc_jsonrpc_api_2(exc: CustomException) -> t.Dict[str, t.Any]:
+        await asyncio.sleep(0)
+        return f"jsonrpc_api_2: {exc.data['message']}"
+
+    # pylint: disable=W0612
+    @jsonrpc_api_2.method('blue2.index')
+    async def index_b2() -> str:
+        await asyncio.sleep(0)
+        return 'b2 index'
+
+    # pylint: disable=W0612
+    @jsonrpc_api_2.method('blue2.errorhandler')
+    async def error_b2() -> t.NoReturn:
+        await asyncio.sleep(0)
+        raise CustomException('Testing error handler', data={'message': 'Flask JSON-RPC', 'code': '0000'})
+
+    app = Flask('test_app', instance_relative_config=True)
+    jsonrpc = JSONRPC(app, '/api', enable_web_browsable_api=True)
+    jsonrpc.register_blueprint(app, jsonrpc_api_1, url_prefix='/b1')
+    jsonrpc.register_blueprint(app, jsonrpc_api_2, url_prefix='/b2')
+
+    with app.test_client() as client:
+        rv = client.post('/api/b1', json={'id': 1, 'jsonrpc': '2.0', 'method': 'blue1.index', 'params': []})
+        assert rv.json == {'id': 1, 'jsonrpc': '2.0', 'result': 'b1 index'}
+        assert rv.status_code == 200
+
+        rv = client.post('/api/b1', json={'id': 1, 'jsonrpc': '2.0', 'method': 'blue1.errorhandler', 'params': []})
+        assert rv.json == {
+            'id': 1,
+            'jsonrpc': '2.0',
+            'error': {
+                'code': -32000,
+                'data': 'jsonrpc_api_1: Flask JSON-RPC',
+                'message': 'Server error',
+                'name': 'ServerError',
+            },
+        }
+        assert rv.status_code == 500
+
+        rv = client.post('/api/b2', json={'id': 1, 'jsonrpc': '2.0', 'method': 'blue2.index', 'params': []})
+        assert rv.json == {'id': 1, 'jsonrpc': '2.0', 'result': 'b2 index'}
+        assert rv.status_code == 200
+
+        rv = client.post('/api/b2', json={'id': 1, 'jsonrpc': '2.0', 'method': 'blue2.errorhandler', 'params': []})
+        assert rv.json == {
+            'id': 1,
+            'jsonrpc': '2.0',
+            'error': {
+                'code': -32000,
+                'data': 'jsonrpc_api_2: Flask JSON-RPC',
+                'message': 'Server error',
+                'name': 'ServerError',
+            },
+        }
+        assert rv.status_code == 500
+
+
 def test_app_create_with_server_name() -> None:
     app = Flask('test_app', instance_relative_config=True)
     app.config.update({'SERVER_NAME': 'domain:80'})
@@ -151,7 +285,8 @@ def test_app_create_with_server_name() -> None:
 
     # pylint: disable=W0612
     @jsonrpc.method('app.index')
-    def index() -> str:
+    async def index() -> str:
+        await asyncio.sleep(0)
         return 'Welcome to Flask JSON-RPC'
 
     with app.test_client() as client:

--- a/tests/unit/test_async_client.py
+++ b/tests/unit/test_async_client.py
@@ -520,6 +520,62 @@ def test_app_class(async_client: 'FlaskClient') -> None:
     assert rv.status_code == 500
 
 
+def test_app_with_invalid_union(async_client: 'FlaskClient') -> None:
+    rv = async_client.post(
+        '/api',
+        json={
+            'id': 1,
+            'jsonrpc': '2.0',
+            'method': 'jsonrpc.invalidUnion1',
+            'params': {'color': {'name': 'Blue', 'tag': 'good'}},
+        },
+    )
+    assert rv.status_code == 400
+    assert rv.json == {
+        'id': 1,
+        'jsonrpc': '2.0',
+        'error': {
+            'code': -32602,
+            'data': {
+                'message': 'the only type of union that is supported is: typing.Union[T, ' 'None] or typing.Optional[T]'
+            },
+            'message': 'Invalid params',
+            'name': 'InvalidParamsError',
+        },
+    }
+
+    rv = async_client.post(
+        '/api',
+        json={
+            'id': 1,
+            'jsonrpc': '2.0',
+            'method': 'jsonrpc.invalidUnion2',
+            'params': {'color': {'name': 'Blue', 'tag': 'good'}},
+        },
+    )
+    assert rv.status_code == 400
+    assert rv.json == {
+        'id': 1,
+        'jsonrpc': '2.0',
+        'error': {
+            'code': -32602,
+            'data': {
+                'message': 'the only type of union that is supported is: typing.Union[T, ' 'None] or typing.Optional[T]'
+            },
+            'message': 'Invalid params',
+            'name': 'InvalidParamsError',
+        },
+    }
+
+
+def test_app_with_pythontypes(async_client: 'FlaskClient') -> None:
+    rv = async_client.post(
+        '/api', json={'id': 1, 'jsonrpc': '2.0', 'method': 'jsonrpc.literalType', 'params': {'x': 'X'}}
+    )
+    assert rv.status_code == 200
+    assert rv.json == {'id': 1, 'jsonrpc': '2.0', 'result': 'X'}
+
+
 def test_app_with_pythonclass(async_client: 'FlaskClient') -> None:
     rv = async_client.post(
         '/api',
@@ -634,61 +690,26 @@ def test_app_with_pythonclass(async_client: 'FlaskClient') -> None:
     assert rv.status_code == 200
     assert rv.json == {'id': 1, 'jsonrpc': '2.0', 'result': None}
 
-
-def test_app_with_invalid_union(async_client: 'FlaskClient') -> None:
     rv = async_client.post(
         '/api',
         json={
             'id': 1,
             'jsonrpc': '2.0',
-            'method': 'jsonrpc.invalidUnion1',
-            'params': {'color': {'name': 'Blue', 'tag': 'good'}},
+            'method': 'jsonrpc.removeColor',
+            'params': {'color': {'id': 100, 'name': 'Blue', 'tag': 'good'}},
         },
     )
-    assert rv.status_code == 400
+    assert rv.status_code == 500
     assert rv.json == {
         'id': 1,
         'jsonrpc': '2.0',
         'error': {
-            'code': -32602,
-            'data': {
-                'message': 'the only type of union that is supported is: typing.Union[T, ' 'None] or typing.Optional[T]'
-            },
-            'message': 'Invalid params',
-            'name': 'InvalidParamsError',
+            'code': -32000,
+            'data': {'color_id': 100, 'reason': 'The color with an ID greater than 10 does not exist.'},
+            'message': 'Server error',
+            'name': 'ServerError',
         },
     }
-
-    rv = async_client.post(
-        '/api',
-        json={
-            'id': 1,
-            'jsonrpc': '2.0',
-            'method': 'jsonrpc.invalidUnion2',
-            'params': {'color': {'name': 'Blue', 'tag': 'good'}},
-        },
-    )
-    assert rv.status_code == 400
-    assert rv.json == {
-        'id': 1,
-        'jsonrpc': '2.0',
-        'error': {
-            'code': -32602,
-            'data': {
-                'message': 'the only type of union that is supported is: typing.Union[T, ' 'None] or typing.Optional[T]'
-            },
-            'message': 'Invalid params',
-            'name': 'InvalidParamsError',
-        },
-    }
-
-
-def test_app_with_pythontypes(async_client: 'FlaskClient') -> None:
-    rv = async_client.post(
-        '/api', json={'id': 1, 'jsonrpc': '2.0', 'method': 'jsonrpc.literalType', 'params': {'x': 'X'}}
-    )
-    assert rv.status_code == 200
-    assert rv.json == {'id': 1, 'jsonrpc': '2.0', 'result': 'X'}
 
 
 def test_app_with_dataclass(async_client: 'FlaskClient') -> None:
@@ -804,6 +825,27 @@ def test_app_with_dataclass(async_client: 'FlaskClient') -> None:
     rv = async_client.post('/api', json={'id': 1, 'jsonrpc': '2.0', 'method': 'jsonrpc.removeCar', 'params': []})
     assert rv.status_code == 200
     assert rv.json == {'id': 1, 'jsonrpc': '2.0', 'result': None}
+
+    rv = async_client.post(
+        '/api',
+        json={
+            'id': 1,
+            'jsonrpc': '2.0',
+            'method': 'jsonrpc.removeCar',
+            'params': {'car': {'id': 100, 'name': 'Fusca', 'tag': 'blue'}},
+        },
+    )
+    assert rv.status_code == 500
+    assert rv.json == {
+        'id': 1,
+        'jsonrpc': '2.0',
+        'error': {
+            'code': -32000,
+            'data': {'car_id': 100, 'reason': 'The car with an ID greater than 10 does not exist.'},
+            'message': 'Server error',
+            'name': 'ServerError',
+        },
+    }
 
 
 def test_app_with_pydantic(async_client: 'FlaskClient') -> None:
@@ -929,6 +971,27 @@ def test_app_with_pydantic(async_client: 'FlaskClient') -> None:
     rv = async_client.post('/api', json={'id': 1, 'jsonrpc': '2.0', 'method': 'jsonrpc.removePet', 'params': []})
     assert rv.status_code == 200
     assert rv.json == {'id': 1, 'jsonrpc': '2.0', 'result': None}
+
+    rv = async_client.post(
+        '/api',
+        json={
+            'id': 1,
+            'jsonrpc': '2.0',
+            'method': 'jsonrpc.removePet',
+            'params': {'pet': {'id': 100, 'name': 'Lou', 'tag': 'dog'}},
+        },
+    )
+    assert rv.status_code == 500
+    assert rv.json == {
+        'id': 1,
+        'jsonrpc': '2.0',
+        'error': {
+            'code': -32000,
+            'data': {'pet_id': 100, 'reason': 'The pet with an ID greater than 10 does not exist.'},
+            'message': 'Server error',
+            'name': 'ServerError',
+        },
+    }
 
 
 def test_app_system_describe(async_client: 'FlaskClient') -> None:


### PR DESCRIPTION
Example:

```
app = Flask('minimal')
jsonrpc = JSONRPC(app, '/api', enable_web_browsable_api=True)

class MyException(Exception):
    pass

@jsonrpc.errorhandler(MyException)
def handle_my_exception(ex: MyException) -> t.Dict[str, t.Any]:
    return {'message': 'It is a custom exception', 'code': '0001'}

@jsonrpc.method('App.failsWithCustomException')
def fails_with_custom_exception(_string: t.Optional[str] = None) -> t.NoReturn:
    raise MyException('example of fail with custom exception that will be handled')
````

Note: The implementation does not support a global error handler, only a local one. In other words, the registration of an error handler will only be available for the JSON-RPC that has been registered.

Resolve #375

<!--
## The seven rules of a great Git commit message

:: Keep in mind: This has all been said before.

1. Separate subject from body with a blank line
2. Limit the subject line to 50 characters
3. Capitalize the subject line
4. Do not end the subject line with a period
5. Use the imperative mood in the subject line
6. Wrap the body at 72 characters
7. Use the body to explain what and why vs. how

For example:

```
Summarize changes in around 50 characters or less

More detailed explanatory text, if necessary. Wrap it to about 72
characters or so. In some contexts, the first line is treated as the
subject of the commit and the rest of the text as the body. The
blank line separating the summary from the body is critical (unless
you omit the body entirely); various tools like `log`, `shortlog`
and `rebase` can get confused if you run the two together.

Explain the problem that this commit is solving. Focus on why you
are making this change as opposed to how (the code explains that).
Are there side effects or other unintuitive consequences of this
change? Here's the place to explain them.

Further paragraphs come after blank lines.

 - Bullet points are okay, too

 - Typically a hyphen or asterisk is used for the bullet, preceded
   by a single space, with blank lines in between, but conventions
   vary here

If you use an issue tracker, put references to them at the bottom,
like this:

Resolves: #123
See also: #456, #789
```

More details: https://chris.beams.io/posts/git-commit/.
-->