### PR TITLE
Bump Typeguard version from 2.x to 4.3.0

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,8 +12,6 @@ updates:
     directory: /requirements
     schedule:
       interval: daily
-    ignore:
-      - dependency-name: "typeguard"
     groups:
       python-requirements:
         patterns:

--- a/examples/async/async_minimal.py
+++ b/examples/async/async_minimal.py
@@ -25,23 +25,12 @@
 # CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
 # ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
-# isort:skip_file
-import os
-import sys
-import asyncio
 from typing import NoReturn, Optional
+import asyncio
 
 from flask import Flask
 
-try:
-    from flask_jsonrpc import JSONRPC
-except ModuleNotFoundError:
-    project_dir, project_module_name = os.path.split(os.path.dirname(os.path.realpath(__file__)))
-    flask_jsonrpc_project_dir = os.path.join(project_dir, os.pardir, 'src')
-    if os.path.exists(flask_jsonrpc_project_dir) and flask_jsonrpc_project_dir not in sys.path:
-        sys.path.append(flask_jsonrpc_project_dir)
-
-    from flask_jsonrpc import JSONRPC
+from flask_jsonrpc import JSONRPC
 
 app = Flask('wba')
 jsonrpc = JSONRPC(app, '/api', enable_web_browsable_api=True)

--- a/examples/auth/auth.py
+++ b/examples/auth/auth.py
@@ -25,9 +25,7 @@
 # CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
 # ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
-# isort:skip_file
-import os
-import sys
+
 import typing as t
 
 from flask import Flask, request
@@ -35,15 +33,7 @@ from flask import Flask, request
 if t.TYPE_CHECKING:
     from flask.typing import ResponseReturnValue
 
-try:
-    from flask_jsonrpc import JSONRPC, JSONRPCView
-except ModuleNotFoundError:
-    project_dir, project_module_name = os.path.split(os.path.dirname(os.path.realpath(__file__)))
-    flask_jsonrpc_project_dir = os.path.join(project_dir, os.pardir, 'src')
-    if os.path.exists(flask_jsonrpc_project_dir) and flask_jsonrpc_project_dir not in sys.path:
-        sys.path.append(flask_jsonrpc_project_dir)
-
-    from flask_jsonrpc import JSONRPC, JSONRPCView
+from flask_jsonrpc import JSONRPC, JSONRPCView
 
 
 class UnauthorizedError(Exception):

--- a/examples/cerberus_params_validator/example1.py
+++ b/examples/cerberus_params_validator/example1.py
@@ -25,23 +25,13 @@
 # CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
 # ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
-# isort:skip_file
-import os
-import sys
 from typing import Any, Dict
 
 from flask import Flask
+
 from cerberus import Validator
 
-try:
-    from flask_jsonrpc import JSONRPC
-except ModuleNotFoundError:
-    project_dir, project_module_name = os.path.split(os.path.dirname(os.path.realpath(__file__)))
-    flask_jsonrpc_project_dir = os.path.join(project_dir, os.pardir, 'src')
-    if os.path.exists(flask_jsonrpc_project_dir) and flask_jsonrpc_project_dir not in sys.path:
-        sys.path.append(flask_jsonrpc_project_dir)
-
-    from flask_jsonrpc import JSONRPC
+from flask_jsonrpc import JSONRPC
 from flask_jsonrpc.exceptions import InvalidParamsError
 
 app = Flask('cerberus')

--- a/examples/cerberus_params_validator/example2.py
+++ b/examples/cerberus_params_validator/example2.py
@@ -25,24 +25,14 @@
 # CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
 # ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
-# isort:skip_file
-import os
-import sys
-from typing import Any, Dict, Optional, Self
+from typing import Any, Dict, Self, Optional
 from dataclasses import dataclass
 
 from flask import Flask
+
 from cerberus import Validator
 
-try:
-    from flask_jsonrpc import JSONRPC
-except ModuleNotFoundError:
-    project_dir, project_module_name = os.path.split(os.path.dirname(os.path.realpath(__file__)))
-    flask_jsonrpc_project_dir = os.path.join(project_dir, os.pardir, 'src')
-    if os.path.exists(flask_jsonrpc_project_dir) and flask_jsonrpc_project_dir not in sys.path:
-        sys.path.append(flask_jsonrpc_project_dir)
-
-    from flask_jsonrpc import JSONRPC
+from flask_jsonrpc import JSONRPC
 from flask_jsonrpc.exceptions import InvalidParamsError
 
 app = Flask('cerberus')

--- a/examples/cerberus_params_validator/example3.py
+++ b/examples/cerberus_params_validator/example3.py
@@ -25,23 +25,13 @@
 # CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
 # ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
-# isort:skip_file
-import os
-import sys
-from typing import Any, Callable, Dict, Optional, Self
+from typing import Any, Dict, Self, Callable, Optional
 
 from flask import Flask
+
 from cerberus import Validator
 
-try:
-    from flask_jsonrpc import JSONRPC
-except ModuleNotFoundError:
-    project_dir, project_module_name = os.path.split(os.path.dirname(os.path.realpath(__file__)))
-    flask_jsonrpc_project_dir = os.path.join(project_dir, os.pardir, 'src')
-    if os.path.exists(flask_jsonrpc_project_dir) and flask_jsonrpc_project_dir not in sys.path:
-        sys.path.append(flask_jsonrpc_project_dir)
-
-    from flask_jsonrpc import JSONRPC
+from flask_jsonrpc import JSONRPC
 from flask_jsonrpc.exceptions import InvalidParamsError
 
 app = Flask('cerberus')

--- a/examples/decorator/decorator.py
+++ b/examples/decorator/decorator.py
@@ -25,22 +25,11 @@
 # CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
 # ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
-# isort:skip_file
-import os
-import sys
 from typing import Any, Callable
 
 from flask import Flask, request
 
-try:
-    from flask_jsonrpc import JSONRPC
-except ModuleNotFoundError:
-    project_dir, project_module_name = os.path.split(os.path.dirname(os.path.realpath(__file__)))
-    flask_jsonrpc_project_dir = os.path.join(project_dir, os.pardir, 'src')
-    if os.path.exists(flask_jsonrpc_project_dir) and flask_jsonrpc_project_dir not in sys.path:
-        sys.path.append(flask_jsonrpc_project_dir)
-
-    from flask_jsonrpc import JSONRPC
+from flask_jsonrpc import JSONRPC
 
 app = Flask('decorator')
 jsonrpc = JSONRPC(app, '/api')

--- a/examples/gevent/run.py
+++ b/examples/gevent/run.py
@@ -25,23 +25,11 @@
 # CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
 # ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
-# isort:skip_file
-import os
-import sys
-
 from flask import Flask
 
 from gevent.pywsgi import WSGIServer
 
-try:
-    from flask_jsonrpc import JSONRPC
-except ModuleNotFoundError:
-    project_dir, project_module_name = os.path.split(os.path.dirname(os.path.realpath(__file__)))
-    flask_jsonrpc_project_dir = os.path.join(project_dir, os.pardir, 'src')
-    if os.path.exists(flask_jsonrpc_project_dir) and flask_jsonrpc_project_dir not in sys.path:
-        sys.path.append(flask_jsonrpc_project_dir)
-
-    from flask_jsonrpc import JSONRPC
+from flask_jsonrpc import JSONRPC
 
 app = Flask('gevent')
 jsonrpc = JSONRPC(app, '/api', enable_web_browsable_api=True)

--- a/examples/hrx/hrx.py
+++ b/examples/hrx/hrx.py
@@ -25,23 +25,11 @@
 # CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
 # ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
-# isort:skip_file
-import os
-import sys
-
 from flask import Flask, render_template
 
-try:
-    from flask_jsonrpc import JSONRPC
-except ModuleNotFoundError:
-    project_dir, project_module_name = os.path.split(os.path.dirname(os.path.realpath(__file__)))
-    flask_jsonrpc_project_dir = os.path.join(project_dir, os.pardir, 'src')
-    if os.path.exists(flask_jsonrpc_project_dir) and flask_jsonrpc_project_dir not in sys.path:
-        sys.path.append(flask_jsonrpc_project_dir)
-
-    from flask_jsonrpc import JSONRPC
-
 from api.hello import hello  # noqa: E402   pylint: disable=C0413,E0611
+
+from flask_jsonrpc import JSONRPC
 
 app = Flask('hrx')
 app.config.from_object('hrx')

--- a/examples/minimal/minimal.py
+++ b/examples/minimal/minimal.py
@@ -25,23 +25,12 @@
 # CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
 # ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
-# isort:skip_file
-import os
-import sys
 import typing as t
 from numbers import Real
 
 from flask import Flask
 
-try:
-    from flask_jsonrpc import JSONRPC
-except ModuleNotFoundError:
-    project_dir, project_module_name = os.path.split(os.path.dirname(os.path.realpath(__file__)))
-    flask_jsonrpc_project_dir = os.path.join(project_dir, os.pardir, 'src')
-    if os.path.exists(flask_jsonrpc_project_dir) and flask_jsonrpc_project_dir not in sys.path:
-        sys.path.append(flask_jsonrpc_project_dir)
-
-    from flask_jsonrpc import JSONRPC
+from flask_jsonrpc import JSONRPC
 
 app = Flask('minimal')
 jsonrpc = JSONRPC(app, '/api', enable_web_browsable_api=True)

--- a/examples/modular/modular.py
+++ b/examples/modular/modular.py
@@ -25,25 +25,14 @@
 # CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
 # ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
-# isort:skip_file
 import typing as t
-import os
-import sys
 
 from flask import Flask
 
-try:
-    from flask_jsonrpc import JSONRPC
-except ModuleNotFoundError:
-    project_dir, project_module_name = os.path.split(os.path.dirname(os.path.realpath(__file__)))
-    flask_jsonrpc_project_dir = os.path.join(project_dir, os.pardir, 'src')
-    if os.path.exists(flask_jsonrpc_project_dir) and flask_jsonrpc_project_dir not in sys.path:
-        sys.path.append(flask_jsonrpc_project_dir)
-
-    from flask_jsonrpc import JSONRPC
-
 from api.user import user  # noqa: E402   pylint: disable=C0413,E0611
 from api.article import article  # noqa: E402   pylint: disable=C0413,E0611
+
+from flask_jsonrpc import JSONRPC
 
 app = Flask('modular')
 jsonrpc = JSONRPC(app, '/api', enable_web_browsable_api=True)

--- a/examples/multiplesite/multiplesite.py
+++ b/examples/multiplesite/multiplesite.py
@@ -25,21 +25,9 @@
 # CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
 # ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
-# isort:skip_file
-import os
-import sys
-
 from flask import Flask
 
-try:
-    from flask_jsonrpc import JSONRPC
-except ModuleNotFoundError:
-    project_dir, project_module_name = os.path.split(os.path.dirname(os.path.realpath(__file__)))
-    flask_jsonrpc_project_dir = os.path.join(project_dir, os.pardir, 'src')
-    if os.path.exists(flask_jsonrpc_project_dir) and flask_jsonrpc_project_dir not in sys.path:
-        sys.path.append(flask_jsonrpc_project_dir)
-
-    from flask_jsonrpc import JSONRPC
+from flask_jsonrpc import JSONRPC
 
 app = Flask('multiplesite')
 jsonrpc_v1 = JSONRPC(app, '/api/v1', enable_web_browsable_api=True)

--- a/examples/openrpc/petstore.py
+++ b/examples/openrpc/petstore.py
@@ -25,27 +25,14 @@
 # CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
 # ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
-# isort:skip_file
-import os
-import sys
-import typing as t
 import random
+import typing as t
 from dataclasses import dataclass
 
 from flask import Flask
 
-try:
-    from flask_jsonrpc import JSONRPC
-except ModuleNotFoundError:
-    project_dir, project_module_name = os.path.split(os.path.dirname(os.path.realpath(__file__)))
-    flask_jsonrpc_project_dir = os.path.join(project_dir, os.pardir, 'src')
-    if os.path.exists(flask_jsonrpc_project_dir) and flask_jsonrpc_project_dir not in sys.path:
-        sys.path.append(flask_jsonrpc_project_dir)
-
-    from flask_jsonrpc import JSONRPC
-
-from flask_jsonrpc.contrib.openrpc import OpenRPC
-from flask_jsonrpc.contrib.openrpc import typing as st
+from flask_jsonrpc import JSONRPC
+from flask_jsonrpc.contrib.openrpc import OpenRPC, typing as st
 
 app = Flask('openrpc')
 jsonrpc = JSONRPC(app, '/api', enable_web_browsable_api=True)

--- a/examples/pydantic/run.py
+++ b/examples/pydantic/run.py
@@ -25,28 +25,15 @@
 # CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
 # ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
-# isort:skip_file
-import os
-import sys
-import typing as t
 import random
+import typing as t
 
 from flask import Flask
 
-try:
-    from flask_jsonrpc import JSONRPC
-except ModuleNotFoundError:
-    project_dir, project_module_name = os.path.split(os.path.dirname(os.path.realpath(__file__)))
-    flask_jsonrpc_project_dir = os.path.join(project_dir, os.pardir, 'src')
-    if os.path.exists(flask_jsonrpc_project_dir) and flask_jsonrpc_project_dir not in sys.path:
-        sys.path.append(flask_jsonrpc_project_dir)
-
-    from flask_jsonrpc import JSONRPC
-
 from pydantic import BaseModel
 
-from flask_jsonrpc.contrib.openrpc import OpenRPC
-from flask_jsonrpc.contrib.openrpc import typing as st
+from flask_jsonrpc import JSONRPC
+from flask_jsonrpc.contrib.openrpc import OpenRPC, typing as st
 
 app = Flask('openrpc')
 jsonrpc = JSONRPC(app, '/api', enable_web_browsable_api=True)

--- a/examples/register_view_func/run.py
+++ b/examples/register_view_func/run.py
@@ -25,24 +25,13 @@
 # CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
 # ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
-# isort:skip_file
-import os
-import sys
+import typing as t
 from typing import Any, Dict, List, Union, NoReturn, Optional
 from numbers import Real
-import typing as t
 
 from flask import Flask
 
-try:
-    from flask_jsonrpc import JSONRPC
-except ModuleNotFoundError:
-    project_dir, project_module_name = os.path.split(os.path.dirname(os.path.realpath(__file__)))
-    flask_jsonrpc_project_dir = os.path.join(project_dir, os.pardir, 'src')
-    if os.path.exists(flask_jsonrpc_project_dir) and flask_jsonrpc_project_dir not in sys.path:
-        sys.path.append(flask_jsonrpc_project_dir)
-
-    from flask_jsonrpc import JSONRPC
+from flask_jsonrpc import JSONRPC
 
 
 class MyApp:

--- a/examples/wba/minimal.py
+++ b/examples/wba/minimal.py
@@ -25,22 +25,11 @@
 # CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
 # ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
-# isort:skip_file
-import os
-import sys
 from typing import NoReturn, Optional
 
 from flask import Flask
 
-try:
-    from flask_jsonrpc import JSONRPC
-except ModuleNotFoundError:
-    project_dir, project_module_name = os.path.split(os.path.dirname(os.path.realpath(__file__)))
-    flask_jsonrpc_project_dir = os.path.join(project_dir, os.pardir, 'src')
-    if os.path.exists(flask_jsonrpc_project_dir) and flask_jsonrpc_project_dir not in sys.path:
-        sys.path.append(flask_jsonrpc_project_dir)
-
-    from flask_jsonrpc import JSONRPC
+from flask_jsonrpc import JSONRPC
 
 app = Flask('wba')
 jsonrpc = JSONRPC(app, '/api', enable_web_browsable_api=True)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "Flask-JSONRPC"
-version = "4.0.0a1"
+version = "4.0.0a3"
 description = "Adds JSONRPC support to Flask."
 readme = {file = "README.md", content-type = "text/markdown"}
 license = {file = "LICENSE.txt"}
@@ -27,10 +27,11 @@ classifiers = [
 requires-python = ">=3.8"
 dependencies = [
     "Flask>=3.0.0,<4.0",
-    "typeguard==2.13.3",
+    "typeguard==4.3.0",
     "typing_extensions>=4.3.0",
     "typing_inspect==0.9.0",
     "pydantic!=1.8,!=1.8.1,!=2.0.0,!=2.0.1,!=2.1.0,<3.0.0,>=1.7.4",
+    "eval_type_backport==0.2.0"
 ]
 
 [project.optional-dependencies]
@@ -134,10 +135,21 @@ combine-as-imports = true
 order-by-type = true
 force-sort-within-sections = true
 split-on-trailing-comma = false
-section-order = ["future", "standard-library", "flask", "third-party", "first-party", "local-folder"]
+section-order = [
+    "future",
+    "standard-library",
+    "typing-extensions",
+    "flask",
+    "pydantic",
+    "third-party",
+    "first-party",
+    "local-folder"
+]
 
 [tool.ruff.lint.isort.sections]
 "flask" = ["flask"]
+"pydantic" = ["pydantic"]
+"typing-extensions" = ["typing_extensions"]
 
 [tool.ruff.lint.pydocstyle]
 convention = "google"

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -4,10 +4,11 @@ Flask>=3.0.0,<4.0  # https://github.com/pallets/flask
 
 # Tools
 # ------------------------------------------------------------------------------
-typeguard==2.13.3  # https://github.com/agronholm/typeguard
+typeguard==4.3.0  # https://github.com/agronholm/typeguard
 typing_extensions>=4.3.0  # https://github.com/python/typing/blob/master/typing_extensions/README.rst
 typing_inspect==0.9.0  # https://github.com/ilevkivskyi/typing_inspect
 
 # Data types
 # ------------------------------------------------------------------------------
 pydantic!=1.8,!=1.8.1,!=2.0.0,!=2.0.1,!=2.1.0,<3.0.0,>=1.7.4  # https://github.com/pydantic/pydantic
+eval-type-backport==0.2.0  # https://github.com/alexmojaki/eval_type_backport

--- a/requirements/tests.txt
+++ b/requirements/tests.txt
@@ -9,7 +9,7 @@ pytest-selenium==4.1.0  # https://github.com/pytest-dev/pytest-selenium
 
 # Type check
 # ------------------------------------------------------------------------------
-typeguard==2.13.3  # https://github.com/agronholm/typeguard
+typeguard==4.3.0  # https://github.com/agronholm/typeguard
 
 # Code quality
 # ------------------------------------------------------------------------------

--- a/requirements/typing.txt
+++ b/requirements/typing.txt
@@ -3,5 +3,5 @@
 mypy==1.11.2;python_version>="3.11"  # https://github.com/python/mypy
 pytype==2024.1.5;python_version>="3.11" and python_version<"3.12"  # https://github.com/google/pytype
 types_setuptools==75.1.0.20240917  # https://github.com/python/typeshed
-typeguard==2.13.3  # https://github.com/agronholm/typeguard
+typeguard==4.3.0  # https://github.com/agronholm/typeguard
 pyright==1.1.383;python_version>="3.11"  # https://github.com/microsoft/pyright

--- a/src/flask_jsonrpc/blueprints.py
+++ b/src/flask_jsonrpc/blueprints.py
@@ -24,16 +24,15 @@
 # CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
 # ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
+from __future__ import annotations
+
 import typing as t
+
+# Python 3.10+
+from typing_extensions import Self
 
 from .globals import default_jsonrpc_site, default_jsonrpc_site_api
 from .wrappers import JSONRPCDecoratorMixin
-
-# Python 3.10+
-try:
-    from typing import Self
-except ImportError:  # pragma: no cover
-    from typing_extensions import Self
 
 if t.TYPE_CHECKING:
     from .site import JSONRPCSite
@@ -45,16 +44,16 @@ class JSONRPCBlueprint(JSONRPCDecoratorMixin):
         self: Self,
         name: str,
         import_name: str,
-        jsonrpc_site: t.Type['JSONRPCSite'] = default_jsonrpc_site,
-        jsonrpc_site_api: t.Type['JSONRPCView'] = default_jsonrpc_site_api,
+        jsonrpc_site: type[JSONRPCSite] = default_jsonrpc_site,
+        jsonrpc_site_api: type[JSONRPCView] = default_jsonrpc_site_api,
     ) -> None:
         self.name = name
         self.import_name = import_name
         self.jsonrpc_site = jsonrpc_site()
         self.jsonrpc_site_api = jsonrpc_site_api
 
-    def get_jsonrpc_site(self: Self) -> 'JSONRPCSite':
+    def get_jsonrpc_site(self: Self) -> JSONRPCSite:
         return self.jsonrpc_site
 
-    def get_jsonrpc_site_api(self: Self) -> t.Type['JSONRPCView']:
+    def get_jsonrpc_site_api(self: Self) -> type[JSONRPCView]:
         return self.jsonrpc_site_api

--- a/src/flask_jsonrpc/contrib/openrpc/__init__.py
+++ b/src/flask_jsonrpc/contrib/openrpc/__init__.py
@@ -24,13 +24,12 @@
 # CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
 # ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
+from __future__ import annotations
+
 import typing as t
 
-# Python 3.11+
-try:
-    from typing import Self
-except ImportError:  # pragma: no cover
-    from typing_extensions import Self
+# Python 3.10+
+from typing_extensions import Self
 
 from .methods import OPENRPC_DISCOVER_METHOD_NAME, openrpc_discover_method
 from .wrappers import OpenRPCExtendSchemaDecoratorMixin
@@ -46,10 +45,10 @@ if t.TYPE_CHECKING:
 class OpenRPC(OpenRPCExtendSchemaDecoratorMixin):
     def __init__(
         self: Self,
-        app: t.Optional['Flask'] = None,
-        jsonrpc_app: t.Optional['JSONRPC'] = None,
+        app: Flask | None = None,
+        jsonrpc_app: JSONRPC | None = None,
         *,
-        openrpc_schema: t.Optional['OpenRPCSchema'] = None,
+        openrpc_schema: OpenRPCSchema | None = None,
     ) -> None:
         self.app = app
         self.jsonrpc_app = jsonrpc_app
@@ -57,7 +56,7 @@ class OpenRPC(OpenRPCExtendSchemaDecoratorMixin):
         if app and jsonrpc_app:
             self.init_app(app, jsonrpc_app)
 
-    def init_app(self: Self, app: 'Flask', jsonrpc_app: 'JSONRPC') -> None:
+    def init_app(self: Self, app: Flask, jsonrpc_app: JSONRPC) -> None:
         jsonrpc_site = jsonrpc_app.get_jsonrpc_site()
         jsonrpc_sites = [japp.get_jsonrpc_site() for japp in jsonrpc_app.jsonrpc_apps]
         jsonrpc_app.get_jsonrpc_site().register(

--- a/src/flask_jsonrpc/contrib/openrpc/methods.py
+++ b/src/flask_jsonrpc/contrib/openrpc/methods.py
@@ -24,6 +24,8 @@
 # CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
 # ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
+from __future__ import annotations
+
 import typing as t
 from collections import OrderedDict
 
@@ -46,7 +48,7 @@ OPENRPC_DISCOVER_SERVICE_METHOD_TYPE: str = 'method'
 
 
 def _openrpc_discover_method(
-    jsonrpc_sites: t.List['JSONRPCSite'], *, openrpc_schema: st.OpenRPCSchema
+    jsonrpc_sites: list[JSONRPCSite], *, openrpc_schema: st.OpenRPCSchema
 ) -> t.Callable[..., st.OpenRPCSchema]:
     @cache
     @extend_schema(
@@ -104,7 +106,7 @@ def _openrpc_discover_method(
 
 
 def openrpc_discover_method(
-    jsonrpc_sites: t.List['JSONRPCSite'], *, openrpc_schema: t.Optional[st.OpenRPCSchema] = None
+    jsonrpc_sites: list[JSONRPCSite], *, openrpc_schema: st.OpenRPCSchema | None = None
 ) -> t.Callable[..., st.OpenRPCSchema]:
     if openrpc_schema is None:
         jsonrpc_site = jsonrpc_sites[0]

--- a/src/flask_jsonrpc/contrib/openrpc/typing.py
+++ b/src/flask_jsonrpc/contrib/openrpc/typing.py
@@ -1,3 +1,31 @@
+# Copyright (c) 2024-2024, Cenobit Technologies, Inc. http://cenobit.es/
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# * Redistributions of source code must retain the above copyright notice,
+#    this list of conditions and the following disclaimer.
+# * Redistributions in binary form must reproduce the above copyright notice,
+#    this list of conditions and the following disclaimer in the documentation
+#    and/or other materials provided with the distribution.
+# * Neither the name of the Cenobit Technologies nor the names of
+#    its contributors may be used to endorse or promote products derived from
+#    this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+from __future__ import annotations
+
 from enum import Enum
 import typing as t
 
@@ -14,40 +42,40 @@ class OAuth2FlowType(Enum):
 
 class OAuth2Flow(BaseModel):
     type: OAuth2FlowType
-    authorization_url: t.Optional[str] = Field(
+    authorization_url: str | None = Field(
         default=None,
         serialization_alias='authorizationUrl',
         validation_alias=AliasChoices('authorizationUrl', 'authorizationUrl'),
     )
-    refresh_url: t.Optional[str] = Field(
+    refresh_url: str | None = Field(
         default=None, serialization_alias='refreshUrl', validation_alias=AliasChoices('refresh_url', 'refreshUrl')
     )
-    token_url: t.Optional[str] = Field(
+    token_url: str | None = Field(
         default=None, serialization_alias='tokenUrl', validation_alias=AliasChoices('token_url', 'tokenUrl')
     )
-    scopes: t.Dict[str, str] = Field(default_factory=dict)
+    scopes: dict[str, str] = Field(default_factory=dict)
 
 
 class OAuth2(BaseModel):
-    flows: t.List[OAuth2Flow]
+    flows: list[OAuth2Flow]
     type: t.Literal['oauth2'] = Field(default='oauth2')
-    description: t.Optional[str] = None
+    description: str | None = None
 
 
 class BearerAuth(BaseModel):
     in_: str = Field(alias='in')
     type: t.Literal['bearer'] = Field(default='bearer')
     name: str = Field(default='Authorization')
-    description: t.Optional[str] = None
-    scopes: t.Dict[str, str] = Field(default_factory=dict)
+    description: str | None = None
+    scopes: dict[str, str] = Field(default_factory=dict)
 
 
 class APIKeyAuth(BaseModel):
     in_: str = Field(alias='in')
     type: t.Literal['apikey'] = Field(default='apikey')
     name: str = Field(default='api_key')
-    description: t.Optional[str] = None
-    scopes: t.Dict[str, str] = Field(default_factory=dict)
+    description: str | None = None
+    scopes: dict[str, str] = Field(default_factory=dict)
 
 
 class ParamStructure(Enum):
@@ -65,7 +93,7 @@ class SchemaDataType(Enum):
     STRING = 'string'
 
     @staticmethod
-    def from_rpc_describe_type(st: str) -> 'SchemaDataType':
+    def from_rpc_describe_type(st: str) -> SchemaDataType:
         type_name = st.lower()
         if type_name == 'number':
             return SchemaDataType.INTEGER
@@ -73,125 +101,121 @@ class SchemaDataType(Enum):
 
 
 class Schema(BaseModel):
-    id: t.Optional[str] = Field(default=None, serialization_alias='$id', validation_alias=AliasChoices('id', '$id'))
-    title: t.Optional[str] = None
-    format: t.Optional[str] = None
-    enum: t.Optional[t.List[t.Any]] = None
-    type: t.Optional[t.Union[SchemaDataType, t.List[SchemaDataType]]] = None
-    all_of: t.Optional[t.List['Schema']] = Field(
+    id: str | None = Field(default=None, serialization_alias='$id', validation_alias=AliasChoices('id', '$id'))
+    title: str | None = None
+    format: str | None = None
+    enum: list[t.Any] | None = None
+    type: SchemaDataType | list[SchemaDataType] | None = None
+    all_of: list[Schema] | None = Field(
         default=None, serialization_alias='allOf', validation_alias=AliasChoices('all_of', 'allOf')
     )
-    any_of: t.Optional[t.List['Schema']] = Field(
+    any_of: list[Schema] | None = Field(
         default=None, serialization_alias='anyOf', validation_alias=AliasChoices('any_of', 'anyOf')
     )
-    one_of: t.Optional[t.List['Schema']] = Field(
+    one_of: list[Schema] | None = Field(
         default=None, serialization_alias='oneOf', validation_alias=AliasChoices('one_of', 'oneOf')
     )
-    not_: t.Optional['Schema'] = Field(
-        default=None, serialization_alias='not', validation_alias=AliasChoices('not_', 'not')
-    )
-    pattern: t.Optional[str] = None
-    minimum: t.Optional[float] = None
-    maximum: t.Optional[float] = None
-    exclusive_minimum: t.Optional[float] = Field(
+    not_: Schema | None = Field(default=None, serialization_alias='not', validation_alias=AliasChoices('not_', 'not'))
+    pattern: str | None = None
+    minimum: float | None = None
+    maximum: float | None = None
+    exclusive_minimum: float | None = Field(
         default=None,
         serialization_alias='exclusiveMinimum',
         validation_alias=AliasChoices('exclusive_minimum', 'exclusiveMinimum'),
     )
-    exclusive_maximum: t.Optional[float] = Field(
+    exclusive_maximum: float | None = Field(
         default=None,
         serialization_alias='exclusiveMaximum',
         validation_alias=AliasChoices('exclusive_maximum', 'exclusiveMaximum'),
     )
-    multiple_of: t.Optional[float] = Field(
+    multiple_of: float | None = Field(
         default=None, serialization_alias='multipleOf', validation_alias=AliasChoices('multiple_of', 'multipleOf')
     )
-    min_length: t.Optional[int] = Field(
+    min_length: int | None = Field(
         default=None, serialization_alias='minLength', validation_alias=AliasChoices('min_length', 'minLength')
     )
-    max_length: t.Optional[int] = Field(
+    max_length: int | None = Field(
         default=None, serialization_alias='maxLength', validation_alias=AliasChoices('max_length', 'maxLength')
     )
-    properties: t.Optional[t.Dict[str, 'Schema']] = None
-    pattern_properties: t.Optional[t.Dict[str, 'Schema']] = Field(
+    properties: dict[str, Schema] | None = None
+    pattern_properties: dict[str, Schema] | None = Field(
         default=None,
         serialization_alias='patternProperties',
         validation_alias=AliasChoices('pattern_properties', 'patternProperties'),
     )
-    additional_properties: t.Optional['Schema'] = Field(
+    additional_properties: Schema | None = Field(
         default=None,
         serialization_alias='additionalProperties',
         validation_alias=AliasChoices('additional_properties', 'additionalProperties'),
     )
-    property_names: t.Optional['Schema'] = Field(
+    property_names: Schema | None = Field(
         default=None,
         serialization_alias='propertyNames',
         validation_alias=AliasChoices('property_names', 'propertyNames'),
     )
-    min_properties: t.Optional[int] = Field(
+    min_properties: int | None = Field(
         default=None,
         serialization_alias='minProperties',
         validation_alias=AliasChoices('min_properties', 'minProperties'),
     )
-    max_properties: t.Optional[int] = Field(
+    max_properties: int | None = Field(
         default=None,
         serialization_alias='maxProperties',
         validation_alias=AliasChoices('max_properties', 'maxProperties'),
     )
-    required: t.Optional[t.List[str]] = None
-    defs: t.Optional[t.Dict[str, 'Schema']] = Field(
+    required: list[str] | None = None
+    defs: dict[str, Schema] | None = Field(
         default=None, serialization_alias='$defs', validation_alias=AliasChoices('defs', '$defs')
     )
-    items: t.Optional['Schema'] = None
-    prefix_items: t.Optional[t.List['Schema']] = Field(
+    items: Schema | None = None
+    prefix_items: list[Schema] | None = Field(
         default=None, serialization_alias='prefixItems', validation_alias=AliasChoices('prefix_items', 'prefixItems')
     )
-    contains: t.Optional['Schema'] = None
-    min_contains: t.Optional[int] = Field(
+    contains: Schema | None = None
+    min_contains: int | None = Field(
         default=None, serialization_alias='minContains', validation_alias=AliasChoices('min_contains', 'minContains')
     )
-    max_contains: t.Optional[int] = Field(
+    max_contains: int | None = Field(
         default=None, serialization_alias='maxContains', validation_alias=AliasChoices('max_contains', 'maxContains')
     )
-    min_items: t.Optional[int] = Field(
+    min_items: int | None = Field(
         default=None, serialization_alias='minItems', validation_alias=AliasChoices('min_items', 'minItems')
     )
-    max_items: t.Optional[int] = Field(
+    max_items: int | None = Field(
         default=None, serialization_alias='maxItems', validation_alias=AliasChoices('max_items', 'maxItems')
     )
-    unique_items: t.Optional[bool] = Field(
+    unique_items: bool | None = Field(
         default=None, serialization_alias='uniqueItems', validation_alias=AliasChoices('unique_items', 'uniqueItems')
     )
-    ref: t.Optional[str] = Field(default=None, serialization_alias='$ref', validation_alias=AliasChoices('ref', '$ref'))
-    description: t.Optional[str] = None
-    deprecated: t.Optional[bool] = None
-    default: t.Optional[t.Any] = None
-    examples: t.Optional[t.List[t.Any]] = None
-    read_only: t.Optional[bool] = Field(
+    ref: str | None = Field(default=None, serialization_alias='$ref', validation_alias=AliasChoices('ref', '$ref'))
+    description: str | None = None
+    deprecated: bool | None = None
+    default: t.Any | None = None
+    examples: list[t.Any] | None = None
+    read_only: bool | None = Field(
         default=None, serialization_alias='readOnly', validation_alias=AliasChoices('read_only', 'readOnly')
     )
-    write_only: t.Optional[bool] = Field(
+    write_only: bool | None = Field(
         default=None, serialization_alias='writeOnly', validation_alias=AliasChoices('write_only', 'writeOnly')
     )
-    const: t.Optional[t.Any] = None
-    dependent_required: t.Optional[t.Dict[str, t.List[str]]] = Field(
+    const: t.Any | None = None
+    dependent_required: dict[str, list[str]] | None = Field(
         default=None,
         serialization_alias='dependentRequired',
         validation_alias=AliasChoices('dependent_required', 'dependentRequired'),
     )
-    dependent_schemas: t.Optional[t.Dict[str, 'Schema']] = Field(
+    dependent_schemas: dict[str, Schema] | None = Field(
         default=None,
         serialization_alias='dependentSchemas',
         validation_alias=AliasChoices('dependent_schemas', 'dependentSchemas'),
     )
-    if_: t.Optional['Schema'] = Field(
-        default=None, serialization_alias='if', validation_alias=AliasChoices('if_', 'if')
-    )
-    then: t.Optional['Schema'] = None
-    else_: t.Optional['Schema'] = Field(
+    if_: Schema | None = Field(default=None, serialization_alias='if', validation_alias=AliasChoices('if_', 'if'))
+    then: Schema | None = None
+    else_: Schema | None = Field(
         default=None, serialization_alias='else', validation_alias=AliasChoices('else_', 'else')
     )
-    schema_: t.Optional[str] = Field(
+    schema_: str | None = Field(
         default=None,
         alias='schema',
         serialization_alias='$schema',
@@ -206,58 +230,58 @@ class Reference(BaseModel):
 class ContentDescriptor(BaseModel):
     name: str
     schema_: Schema = Field(alias='schema', validation_alias=AliasChoices('schema_', 'schema'))
-    summary: t.Optional[str] = None
-    description: t.Optional[str] = None
-    required: t.Optional[bool] = None
-    deprecated: t.Optional[bool] = None
+    summary: str | None = None
+    description: str | None = None
+    required: bool | None = None
+    deprecated: bool | None = None
 
 
 class Contact(BaseModel):
-    name: t.Optional[str] = None
-    url: t.Optional[str] = None
-    email: t.Optional[str] = None
+    name: str | None = None
+    url: str | None = None
+    email: str | None = None
 
 
 class License(BaseModel):
     name: str
-    url: t.Optional[str] = None
+    url: str | None = None
 
 
 class Info(BaseModel):
     title: str
     version: str
-    description: t.Optional[str] = None
-    terms_of_service: t.Optional[str] = Field(
+    description: str | None = None
+    terms_of_service: str | None = Field(
         default=None,
         serialization_alias='termsOfService',
         validation_alias=AliasChoices('terms_of_service', 'termsOfService'),
     )
-    contact: t.Optional[Contact] = None
-    license_: t.Optional[License] = Field(
+    contact: Contact | None = None
+    license_: License | None = Field(
         default=None, alias='license', validation_alias=AliasChoices('license_', 'license')
     )
 
 
 class ServerVariable(BaseModel):
     default: str
-    enum: t.Optional[t.List[str]] = None
-    description: t.Optional[str] = None
+    enum: list[str] | None = None
+    description: str | None = None
 
 
 class Server(BaseModel):
     url: str
     name: str = Field(default='default')
-    summary: t.Optional[str] = None
-    description: t.Optional[str] = None
-    variables: t.Optional[t.Dict[str, ServerVariable]] = None
+    summary: str | None = None
+    description: str | None = None
+    variables: dict[str, ServerVariable] | None = None
 
 
 class Example(BaseModel):
     name: str
     value: t.Any
-    summary: t.Optional[str] = None
-    description: t.Optional[str] = None
-    external_value: t.Optional[str] = Field(
+    summary: str | None = None
+    description: str | None = None
+    external_value: str | None = Field(
         default=None,
         serialization_alias='externalValue',
         validation_alias=AliasChoices('external_value', 'externalValue'),
@@ -265,55 +289,55 @@ class Example(BaseModel):
 
 
 class ExamplePairing(BaseModel):
-    name: t.Optional[str] = None
-    params: t.Optional[t.List[Example]] = None
-    summary: t.Optional[str] = None
-    description: t.Optional[str] = None
-    result: t.Optional[Example] = None
+    name: str | None = None
+    params: list[Example] | None = None
+    summary: str | None = None
+    description: str | None = None
+    result: Example | None = None
 
 
 class Link(BaseModel):
     name: str
-    summary: t.Optional[str] = None
-    description: t.Optional[str] = None
-    method: t.Optional[str] = None
-    params: t.Optional[t.Any] = None
-    server: t.Optional[Server] = None
+    summary: str | None = None
+    description: str | None = None
+    method: str | None = None
+    params: t.Any | None = None
+    server: Server | None = None
 
 
 class Error(BaseModel):
     code: int
     message: str
-    data: t.Optional[t.Any] = None
+    data: t.Any | None = None
 
 
 class ExternalDocumentation(BaseModel):
     url: str
-    description: t.Optional[str] = None
+    description: str | None = None
 
 
 class Tag(BaseModel):
     name: str
-    summary: t.Optional[str] = None
-    description: t.Optional[str] = None
-    external_docs: t.Optional[ExternalDocumentation] = Field(
+    summary: str | None = None
+    description: str | None = None
+    external_docs: ExternalDocumentation | None = Field(
         default=None, serialization_alias='externalDocs', validation_alias=AliasChoices('external_docs', 'externalDocs')
     )
 
 
 class Components(BaseModel):
-    content_descriptors: t.Optional[t.Dict[str, ContentDescriptor]] = Field(
+    content_descriptors: dict[str, ContentDescriptor] | None = Field(
         default=None,
         serialization_alias='contentDescriptors',
         validation_alias=AliasChoices('content_descriptors', 'contentDescriptors'),
     )
-    schemas: t.Optional[t.Dict[str, Schema]] = None
-    examples: t.Optional[t.Dict[str, Example]] = None
-    links: t.Optional[t.Dict[str, Link]] = None
-    errors: t.Optional[t.Dict[str, Error]] = None
-    example_pairing_objects: t.Optional[t.Dict[str, ExamplePairing]] = None
-    tags: t.Optional[t.Dict[str, Tag]] = None
-    x_security_schemes: t.Optional[t.Dict[str, t.Union[OAuth2, BearerAuth, APIKeyAuth]]] = Field(
+    schemas: dict[str, Schema] | None = None
+    examples: dict[str, Example] | None = None
+    links: dict[str, Link] | None = None
+    errors: dict[str, Error] | None = None
+    example_pairing_objects: dict[str, ExamplePairing] | None = None
+    tags: dict[str, Tag] | None = None
+    x_security_schemes: dict[str, OAuth2 | BearerAuth | APIKeyAuth] | None = Field(
         default=None,
         serialization_alias='x-security-schemes',
         validation_alias=AliasChoices('x_security_schemes', 'x-security-schemes'),
@@ -322,25 +346,25 @@ class Components(BaseModel):
 
 class Method(BaseModel):
     name: str
-    params: t.List[ContentDescriptor]
+    params: list[ContentDescriptor]
     result: ContentDescriptor
-    tags: t.Optional[t.List[Tag]] = None
-    summary: t.Optional[str] = None
-    description: t.Optional[str] = None
-    external_docs: t.Optional[ExternalDocumentation] = Field(
+    tags: list[Tag] | None = None
+    summary: str | None = None
+    description: str | None = None
+    external_docs: ExternalDocumentation | None = Field(
         default=None, serialization_alias='externalDocs', validation_alias=AliasChoices('external_docs', 'externalDocs')
     )
-    deprecated: t.Optional[bool] = None
-    servers: t.Optional[t.List[Server]] = None
-    errors: t.Optional[t.List[Error]] = None
-    links: t.Optional[t.List[Link]] = None
-    param_structure: t.Optional[ParamStructure] = Field(
+    deprecated: bool | None = None
+    servers: list[Server] | None = None
+    errors: list[Error] | None = None
+    links: list[Link] | None = None
+    param_structure: ParamStructure | None = Field(
         default=None,
         serialization_alias='paramStructure',
         validation_alias=AliasChoices('param_structure', 'paramStructure'),
     )
-    examples: t.Optional[t.List[ExamplePairing]] = None
-    x_security: t.Optional[t.Dict[str, t.List[str]]] = Field(
+    examples: list[ExamplePairing] | None = None
+    x_security: dict[str, list[str]] | None = Field(
         default=None, serialization_alias='x-security', validation_alias=AliasChoices('x_security', 'x-security')
     )
 
@@ -348,9 +372,9 @@ class Method(BaseModel):
 class OpenRPCSchema(BaseModel):
     info: Info
     openrpc: str = Field(default=OPENRPC_VERSION_DEFAULT)
-    methods: t.List[Method] = []
-    servers: t.Union[t.List[Server], Server] = Server(name='default', url='localhost')
-    components: t.Optional[Components] = None
-    external_docs: t.Optional[ExternalDocumentation] = Field(
+    methods: list[Method] = []
+    servers: list[Server] | Server = Server(name='default', url='localhost')
+    components: Components | None = None
+    external_docs: ExternalDocumentation | None = Field(
         default=None, serialization_alias='externalDocs', validation_alias=AliasChoices('external_docs', 'externalDocs')
     )

--- a/src/flask_jsonrpc/contrib/openrpc/utils.py
+++ b/src/flask_jsonrpc/contrib/openrpc/utils.py
@@ -24,6 +24,8 @@
 # CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
 # ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
+from __future__ import annotations
+
 import typing as t
 
 from pydantic.main import BaseModel
@@ -32,37 +34,37 @@ from . import typing as st
 
 
 class MethodExtendSchema(BaseModel):
-    name: t.Optional[str] = None
-    params: t.Optional[t.List[st.ContentDescriptor]] = None
-    result: t.Optional[st.ContentDescriptor] = None
-    tags: t.Optional[t.List[st.Tag]] = None
-    summary: t.Optional[str] = None
-    description: t.Optional[str] = None
-    external_docs: t.Optional[st.ExternalDocumentation] = None
-    deprecated: t.Optional[bool] = None
-    servers: t.Optional[t.List[st.Server]] = None
-    errors: t.Optional[t.List[st.Error]] = None
-    links: t.Optional[t.List[st.Link]] = None
-    param_structure: t.Optional[st.ParamStructure] = None
-    examples: t.Optional[t.List[st.ExamplePairing]] = None
-    x_security: t.Optional[t.Dict[str, t.List[str]]] = None
+    name: str | None = None
+    params: list[st.ContentDescriptor] | None = None
+    result: st.ContentDescriptor | None = None
+    tags: list[st.Tag] | None = None
+    summary: str | None = None
+    description: str | None = None
+    external_docs: st.ExternalDocumentation | None = None
+    deprecated: bool | None = None
+    servers: list[st.Server] | None = None
+    errors: list[st.Error] | None = None
+    links: list[st.Link] | None = None
+    param_structure: st.ParamStructure | None = None
+    examples: list[st.ExamplePairing] | None = None
+    x_security: dict[str, list[str]] | None = None
 
 
 def extend_schema(
-    name: t.Optional[str] = None,
-    params: t.Optional[t.List[st.ContentDescriptor]] = None,
-    tags: t.Optional[t.List[st.Tag]] = None,
-    summary: t.Optional[str] = None,
-    description: t.Optional[str] = None,
-    external_docs: t.Optional[st.ExternalDocumentation] = None,
-    result: t.Optional[st.ContentDescriptor] = None,
-    deprecated: t.Optional[bool] = None,
-    servers: t.Optional[t.List[st.Server]] = None,
-    errors: t.Optional[t.List[st.Error]] = None,
-    links: t.Optional[t.List[st.Link]] = None,
-    param_structure: t.Optional[st.ParamStructure] = None,
-    examples: t.Optional[t.List[st.ExamplePairing]] = None,
-    x_security: t.Optional[t.Dict[str, t.List[str]]] = None,
+    name: str | None = None,
+    params: list[st.ContentDescriptor] | None = None,
+    tags: list[st.Tag] | None = None,
+    summary: str | None = None,
+    description: str | None = None,
+    external_docs: st.ExternalDocumentation | None = None,
+    result: st.ContentDescriptor | None = None,
+    deprecated: bool | None = None,
+    servers: list[st.Server] | None = None,
+    errors: list[st.Error] | None = None,
+    links: list[st.Link] | None = None,
+    param_structure: st.ParamStructure | None = None,
+    examples: list[st.ExamplePairing] | None = None,
+    x_security: dict[str, list[str]] | None = None,
 ) -> t.Callable[..., t.Any]:
     def decorator(fn: t.Callable[..., t.Any]) -> t.Callable[..., t.Any]:
         method_schema = MethodExtendSchema(

--- a/src/flask_jsonrpc/contrib/openrpc/wrappers.py
+++ b/src/flask_jsonrpc/contrib/openrpc/wrappers.py
@@ -24,15 +24,14 @@
 # CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
 # ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
+from __future__ import annotations
+
 import typing as t
 
-from .utils import extend_schema
+# Python 3.10+
+from typing_extensions import Self
 
-# Python 3.11+
-try:
-    from typing import Self
-except ImportError:  # pragma: no cover
-    from typing_extensions import Self
+from .utils import extend_schema
 
 
 class OpenRPCExtendSchemaDecoratorMixin:

--- a/src/flask_jsonrpc/descriptor.py
+++ b/src/flask_jsonrpc/descriptor.py
@@ -24,18 +24,17 @@
 # CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
 # ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
+from __future__ import annotations
+
 import typing as t
 from collections import OrderedDict
 from urllib.parse import urlsplit
 
+# Python 3.10+
+from typing_extensions import Self
+
 from . import typing as fjt  # pylint: disable=W0404
 from .helpers import from_python_type
-
-# Python 3.10+
-try:
-    from typing import Self
-except ImportError:  # pragma: no cover
-    from typing_extensions import Self
 
 if t.TYPE_CHECKING:
     from flask_jsonrpc.site import JSONRPCSite
@@ -45,11 +44,11 @@ JSONRPC_DESCRIBE_SERVICE_METHOD_TYPE: str = 'method'
 
 
 class JSONRPCServiceDescriptor:
-    def __init__(self: Self, jsonrpc_site: 'JSONRPCSite') -> None:
+    def __init__(self: Self, jsonrpc_site: JSONRPCSite) -> None:
         self.jsonrpc_site = jsonrpc_site
         self.register(jsonrpc_site)
 
-    def register(self: Self, jsonrpc_site: 'JSONRPCSite') -> None:
+    def register(self: Self, jsonrpc_site: JSONRPCSite) -> None:
         def describe() -> fjt.ServiceDescribe:
             return self.service_describe()
 
@@ -69,7 +68,7 @@ class JSONRPCServiceDescriptor:
 
     def service_method_params_desc(
         self: Self, view_func: t.Callable[..., t.Any]
-    ) -> t.List[fjt.ServiceMethodParamsDescribe]:
+    ) -> list[fjt.ServiceMethodParamsDescribe]:
         return [
             fjt.ServiceMethodParamsDescribe(name=name, type=self.python_type_name(tp))
             for name, tp in getattr(view_func, 'jsonrpc_method_params', {}).items()

--- a/src/flask_jsonrpc/encoders.py
+++ b/src/flask_jsonrpc/encoders.py
@@ -24,6 +24,8 @@
 # CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
 # ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
+from __future__ import annotations
+
 from enum import Enum
 from types import GeneratorType
 import typing as t

--- a/src/flask_jsonrpc/exceptions.py
+++ b/src/flask_jsonrpc/exceptions.py
@@ -24,17 +24,16 @@
 # CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
 # ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
+from __future__ import annotations
+
 import sys
 import typing as t
 import traceback
 
-from flask import current_app
-
 # Python 3.10+
-try:
-    from typing import Self
-except ImportError:  # pragma: no cover
-    from typing_extensions import Self
+from typing_extensions import Self
+
+from flask import current_app
 
 try:
     from flaskext.babel import gettext as _  # type: ignore
@@ -57,16 +56,16 @@ class JSONRPCError(Exception):
     """
 
     code: int = 0
-    message: t.Optional[str] = None
-    data: t.Optional[t.Any] = None
+    message: str | None = None
+    data: t.Any | None = None
     status_code: int = 400
 
     def __init__(
         self: Self,
-        message: t.Optional[str] = None,
-        code: t.Optional[int] = None,
-        data: t.Optional[t.Any] = None,  # noqa: ANN401
-        status_code: t.Optional[int] = None,
+        message: str | None = None,
+        code: int | None = None,
+        data: t.Any | None = None,  # noqa: ANN401
+        status_code: int | None = None,
     ) -> None:
         """Setup the Exception and overwrite the default message"""
         super().__init__()
@@ -80,7 +79,7 @@ class JSONRPCError(Exception):
             self.status_code = status_code
 
     @property
-    def jsonrpc_format(self: Self) -> t.Dict[str, t.Any]:
+    def jsonrpc_format(self: Self) -> dict[str, t.Any]:
         """Return the Exception data in a format for JSON-RPC"""
         error = {'name': self.__class__.__name__, 'code': self.code, 'message': self.message, 'data': self.data}
 

--- a/src/flask_jsonrpc/funcutils.py
+++ b/src/flask_jsonrpc/funcutils.py
@@ -24,6 +24,8 @@
 # CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
 # ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
+from __future__ import annotations
+
 import typing as t
 import inspect
 import dataclasses
@@ -96,7 +98,7 @@ def loads(param_type: t.Any, param_value: t.Any) -> t.Any:  # noqa: ANN401, C901
     return param_value
 
 
-def bindfy(view_func: t.Callable[..., t.Any], params: t.Dict[str, t.Any]) -> t.Dict[str, t.Any]:  # noqa: ANN401
+def bindfy(view_func: t.Callable[..., t.Any], params: dict[str, t.Any]) -> dict[str, t.Any]:  # noqa: ANN401
     binded_params = {}
     view_func_params = getattr(view_func, 'jsonrpc_method_params', {})
     for param_name, param_type in view_func_params.items():

--- a/src/flask_jsonrpc/globals.py
+++ b/src/flask_jsonrpc/globals.py
@@ -24,10 +24,10 @@
 # CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
 # ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
-import typing as t
+from __future__ import annotations
 
 from .site import JSONRPCSite
 from .views import JSONRPCView
 
-default_jsonrpc_site: t.Type[JSONRPCSite] = JSONRPCSite
-default_jsonrpc_site_api: t.Type[JSONRPCView] = JSONRPCView
+default_jsonrpc_site: type[JSONRPCSite] = JSONRPCSite
+default_jsonrpc_site_api: type[JSONRPCView] = JSONRPCView

--- a/src/flask_jsonrpc/helpers.py
+++ b/src/flask_jsonrpc/helpers.py
@@ -24,6 +24,8 @@
 # CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
 # ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
+from __future__ import annotations
+
 import typing as t
 from operator import getitem
 import itertools
@@ -61,7 +63,7 @@ def urn(name: str, *args: t.Any) -> str:  # noqa: ANN401
     return f"urn:{name}{sep}{st.replace('::', ':')}".lower()
 
 
-def from_python_type(tp: t.Any, default: 't.Optional[JSONRPCNewType]' = Object) -> 't.Optional[JSONRPCNewType]':  # noqa: ANN401
+def from_python_type(tp: t.Any, default: JSONRPCNewType | None = Object) -> JSONRPCNewType | None:  # noqa: ANN401
     """Convert Python type to JSONRPCNewType.
 
     >>> str(from_python_type(str))

--- a/src/flask_jsonrpc/settings.py
+++ b/src/flask_jsonrpc/settings.py
@@ -24,19 +24,18 @@
 # CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
 # ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
+from __future__ import annotations
+
 import typing as t
 
 # Python 3.10+
-try:
-    from typing import Self
-except ImportError:  # pragma: no cover
-    from typing_extensions import Self
+from typing_extensions import Self
 
 DEFAULTS = {'DEFAULT_JSONRPC_METHOD': {'VALIDATE': True, 'NOTIFICATION': True}}
 
 
 class JSONRPCSettings:
-    def __init__(self: Self, defaults: t.Optional[t.Dict[str, t.Any]] = None) -> None:
+    def __init__(self: Self, defaults: dict[str, t.Any] | None = None) -> None:
         self.defaults = defaults or DEFAULTS
         self.setup(self.defaults)
 
@@ -50,7 +49,7 @@ class JSONRPCSettings:
         return val
 
     # XXX: https://mypyc.readthedocs.io/en/latest/differences_from_python.html#monkey-patching
-    def setup(self: Self, defaults: t.Dict[str, t.Any]) -> None:
+    def setup(self: Self, defaults: dict[str, t.Any]) -> None:
         for attr, val in defaults.items():
             setattr(JSONRPCSettings, attr, val)
 

--- a/src/flask_jsonrpc/types.py
+++ b/src/flask_jsonrpc/types.py
@@ -24,19 +24,20 @@
 # CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
 # ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
+from __future__ import annotations
+
 from types import GeneratorType
 import typing as t
 from numbers import Real, Integral, Rational
 from collections import OrderedDict, deque, defaultdict
 from collections.abc import Mapping
 
-from typing_inspect import is_new_type  # type: ignore
+from typing_extensions import (
+    Self,  # Python 3.10+
+    Literal,  # Python 3.8+
+)
 
-# Python 3.11+
-try:
-    from typing import Self
-except ImportError:  # pragma: no cover
-    from typing_extensions import Self
+from typing_inspect import is_new_type  # type: ignore
 
 # Python 3.10+
 try:
@@ -45,15 +46,9 @@ except ImportError:  # pragma: no cover
     UnionType = None  # type: ignore
     NoneType = type(None)  # type: ignore
 
-# Python 3.8+
-try:
-    from typing_extensions import Literal
-except ImportError:  # pragma: no cover
-    from typing import Literal  # type: ignore  # pylint: disable=C0412
-
 
 class JSONRPCNewType:
-    def __init__(self: Self, name: str, *types: t.Union[type, t.Tuple[t.Union[type, t.Tuple[type, ...]], ...]]) -> None:
+    def __init__(self: Self, name: str, *types: type | tuple[type | tuple[type, ...], ...]) -> None:
         self.name = name
         self.types = types
 

--- a/src/flask_jsonrpc/typing.py
+++ b/src/flask_jsonrpc/typing.py
@@ -24,6 +24,8 @@
 # CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
 # ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
+from __future__ import annotations
+
 import sys
 import typing as t
 
@@ -39,13 +41,13 @@ else:  # pragma: no cover
 class ServiceMethodParamsDescribe(BaseModel):
     type: str
     name: str
-    required: t.Optional[bool] = None
-    nullable: t.Optional[bool] = None
-    minimum: t.Optional[int] = None
-    maximum: t.Optional[int] = None
-    pattern: t.Optional[str] = None
-    length: t.Optional[int] = None
-    description: t.Optional[str] = None
+    required: bool | None = None
+    nullable: bool | None = None
+    minimum: int | None = None
+    maximum: int | None = None
+    pattern: str | None = None
+    length: int | None = None
+    description: str | None = None
 
 
 class ServiceMethodReturnsDescribe(BaseModel):
@@ -54,21 +56,21 @@ class ServiceMethodReturnsDescribe(BaseModel):
 
 class ServiceMethodDescribe(BaseModel):
     type: str
-    description: t.Optional[str] = None
-    options: t.Dict[str, t.Any] = {}
-    params: t.List[ServiceMethodParamsDescribe] = []
+    description: str | None = None
+    options: dict[str, t.Any] = {}
+    params: list[ServiceMethodParamsDescribe] = []
     returns: ServiceMethodReturnsDescribe
 
 
 class ServiceServersDescribe(BaseModel):
     url: str
-    description: t.Optional[str] = None
+    description: str | None = None
 
 
 class ServiceDescribe(BaseModel):
     id: str
     version: str
     name: str
-    description: t.Optional[str] = None
-    servers: t.List[ServiceServersDescribe]
+    description: str | None = None
+    servers: list[ServiceServersDescribe]
     methods: OrderedDict[str, ServiceMethodDescribe]

--- a/src/flask_jsonrpc/views.py
+++ b/src/flask_jsonrpc/views.py
@@ -24,7 +24,12 @@
 # CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
 # ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
+from __future__ import annotations
+
 import typing as t
+
+# Python 3.10+
+from typing_extensions import Self
 
 from flask import typing as ft, current_app, make_response
 from flask.views import MethodView
@@ -33,18 +38,12 @@ from .site import JSONRPC_VERSION_DEFAULT, JSONRPC_DEFAULT_HTTP_HEADERS
 from .encoders import jsonify
 from .exceptions import JSONRPCError
 
-# Python 3.10+
-try:
-    from typing import Self
-except ImportError:  # pragma: no cover
-    from typing_extensions import Self
-
 if t.TYPE_CHECKING:
     from .site import JSONRPCSite
 
 
 class JSONRPCView(MethodView):
-    def __init__(self: Self, jsonrpc_site: 'JSONRPCSite') -> None:
+    def __init__(self: Self, jsonrpc_site: JSONRPCSite) -> None:
         self.jsonrpc_site = jsonrpc_site
 
     def post(self: Self) -> ft.ResponseReturnValue:

--- a/tests/unit/test_app.py
+++ b/tests/unit/test_app.py
@@ -191,7 +191,7 @@ def test_app_create_modular_using_error_handler() -> None:
     jsonrpc_api_1 = JSONRPCBlueprint('jsonrpc_api_1', __name__)
 
     @jsonrpc_api_1.errorhandler(CustomException)
-    def handle_custom_exc_jsonrpc_api_1(exc: CustomException) -> t.Dict[str, t.Any]:
+    def handle_custom_exc_jsonrpc_api_1(exc: CustomException) -> str:
         return f"jsonrpc_api_1: {exc.data['message']}"
 
     # pylint: disable=W0612
@@ -207,7 +207,7 @@ def test_app_create_modular_using_error_handler() -> None:
     jsonrpc_api_2 = JSONRPCBlueprint('jsonrpc_api_2', __name__)
 
     @jsonrpc_api_2.errorhandler(CustomException)
-    def handle_custom_exc_jsonrpc_api_2(exc: CustomException) -> t.Dict[str, t.Any]:
+    def handle_custom_exc_jsonrpc_api_2(exc: CustomException) -> str:
         return f"jsonrpc_api_2: {exc.data['message']}"
 
     # pylint: disable=W0612
@@ -376,7 +376,7 @@ def test_app_create_with_method_without_annotation_on_return() -> None:
         assert rv.json == {
             'error': {
                 'code': -32602,
-                'data': {'message': 'return type of str must be a type; got NoneType instead'},
+                'data': {'message': 'return type of str must be a type; got None instead'},
                 'message': 'Invalid params',
                 'name': 'InvalidParamsError',
             },

--- a/tests/unit/test_async_app.py
+++ b/tests/unit/test_async_app.py
@@ -395,7 +395,7 @@ def test_app_create_with_method_without_annotation_on_return() -> None:
         assert rv.json == {
             'error': {
                 'code': -32602,
-                'data': {'message': 'return type of str must be a type; got NoneType instead'},
+                'data': {'message': 'return type of str must be a type; got None instead'},
                 'message': 'Invalid params',
                 'name': 'InvalidParamsError',
             },

--- a/tests/unit/test_async_client.py
+++ b/tests/unit/test_async_client.py
@@ -50,6 +50,21 @@ def test_app_greeting(async_client: 'FlaskClient') -> None:
     assert rv.json == {'id': 1, 'jsonrpc': '2.0', 'result': 'Hello Flask'}
     assert rv.status_code == 200
 
+    rv = async_client.post(
+        '/api', json={'id': 1, 'jsonrpc': '2.0', 'method': 'jsonrpc.greeting', 'params': {'name': 1}}
+    )
+    assert rv.json == {
+        'id': 1,
+        'jsonrpc': '2.0',
+        'error': {
+            'code': -32602,
+            'data': {'message': 'argument "name" (int) is not an instance of str'},
+            'message': 'Invalid params',
+            'name': 'InvalidParamsError',
+        },
+    }
+    assert rv.status_code == 400
+
 
 def test_app_greeting_with_different_content_types(async_client: 'FlaskClient') -> None:
     rv = async_client.post(
@@ -173,7 +188,7 @@ def test_app_greeting_raise_invalid_params_error(async_client: 'FlaskClient') ->
         'jsonrpc': '2.0',
         'error': {
             'code': -32602,
-            'data': {'message': 'type of argument "name" must be str; got int instead'},
+            'data': {'message': 'argument "name" (int) is not an instance of str'},
             'message': 'Invalid params',
             'name': 'InvalidParamsError',
         },
@@ -188,7 +203,7 @@ def test_app_greeting_raise_invalid_params_error(async_client: 'FlaskClient') ->
         'jsonrpc': '2.0',
         'error': {
             'code': -32602,
-            'data': {'message': 'type of argument "name" must be str; got int instead'},
+            'data': {'message': 'argument "name" (int) is not an instance of str'},
             'message': 'Invalid params',
             'name': 'InvalidParamsError',
         },
@@ -225,16 +240,13 @@ def test_app_echo(async_client: 'FlaskClient') -> None:
     rv = async_client.post(
         '/api', json={'id': 1, 'jsonrpc': '2.0', 'method': 'jsonrpc.echo', 'params': {'string': None}}
     )
-    assert rv.json == {
-        'id': 1,
-        'jsonrpc': '2.0',
-        'error': {
-            'code': -32602,
-            'data': {'message': "missing a required argument: 'string'"},
-            'message': 'Invalid params',
-            'name': 'InvalidParamsError',
-        },
-    }
+    json_data = rv.get_json()
+    assert json_data['id'] == 1
+    assert json_data['jsonrpc'] == '2.0'
+    assert json_data['error']['code'] == -32602
+    assert "missing 1 required positional argument: 'string'" in json_data['error']['data']['message']
+    assert json_data['error']['message'] == 'Invalid params'
+    assert json_data['error']['name'] == 'InvalidParamsError'
     assert rv.status_code == 400
 
 
@@ -258,7 +270,7 @@ def test_app_echo_raise_invalid_params_error(async_client: 'FlaskClient') -> Non
         'jsonrpc': '2.0',
         'error': {
             'code': -32602,
-            'data': {'message': 'type of argument "string" must be str; got int instead'},
+            'data': {'message': 'argument "string" (int) is not an instance of str'},
             'message': 'Invalid params',
             'name': 'InvalidParamsError',
         },
@@ -266,29 +278,23 @@ def test_app_echo_raise_invalid_params_error(async_client: 'FlaskClient') -> Non
     assert rv.status_code == 400
 
     rv = async_client.post('/api', json={'id': 1, 'jsonrpc': '2.0', 'method': 'jsonrpc.echo', 'params': {'name': 2}})
-    assert rv.json == {
-        'id': 1,
-        'jsonrpc': '2.0',
-        'error': {
-            'code': -32602,
-            'data': {'message': "missing a required argument: 'string'"},
-            'message': 'Invalid params',
-            'name': 'InvalidParamsError',
-        },
-    }
+    json_data = rv.get_json()
+    assert json_data['id'] == 1
+    assert json_data['jsonrpc'] == '2.0'
+    assert json_data['error']['code'] == -32602
+    assert "missing 1 required positional argument: 'string'" in json_data['error']['data']['message']
+    assert json_data['error']['message'] == 'Invalid params'
+    assert json_data['error']['name'] == 'InvalidParamsError'
     assert rv.status_code == 400
 
     rv = async_client.post('/api', json={'id': 1, 'jsonrpc': '2.0', 'method': 'jsonrpc.echo'})
-    assert rv.json == {
-        'id': 1,
-        'jsonrpc': '2.0',
-        'error': {
-            'code': -32602,
-            'data': {'message': "missing a required argument: 'string'"},
-            'message': 'Invalid params',
-            'name': 'InvalidParamsError',
-        },
-    }
+    json_data = rv.get_json()
+    assert json_data['id'] == 1
+    assert json_data['jsonrpc'] == '2.0'
+    assert json_data['error']['code'] == -32602
+    assert "missing 1 required positional argument: 'string'" in json_data['error']['data']['message']
+    assert json_data['error']['message'] == 'Invalid params'
+    assert json_data['error']['name'] == 'InvalidParamsError'
     assert rv.status_code == 400
 
 
@@ -390,16 +396,13 @@ def test_app_sum(async_client: 'FlaskClient') -> None:
 
     data = {'id': 1, 'jsonrpc': '2.0', 'method': 'jsonrpc.sum', 'params': {'a': None, 'b': None}}
     rv = async_client.post('/api', json=data)
-    assert rv.json == {
-        'id': 1,
-        'jsonrpc': '2.0',
-        'error': {
-            'code': -32602,
-            'data': {'message': "missing a required argument: 'a'"},
-            'message': 'Invalid params',
-            'name': 'InvalidParamsError',
-        },
-    }
+    json_data = rv.get_json()
+    assert json_data['id'] == 1
+    assert json_data['jsonrpc'] == '2.0'
+    assert json_data['error']['code'] == -32602
+    assert "missing 2 required positional arguments: 'a' and 'b'" in json_data['error']['data']['message']
+    assert json_data['error']['message'] == 'Invalid params'
+    assert json_data['error']['name'] == 'InvalidParamsError'
     assert rv.status_code == 400
 
 
@@ -407,6 +410,61 @@ def test_app_decorators(async_client: 'FlaskClient') -> None:
     data = {'id': 1, 'jsonrpc': '2.0', 'method': 'jsonrpc.decorators', 'params': ['Python']}
     rv = async_client.post('/api', json=data)
     assert rv.json == {'id': 1, 'jsonrpc': '2.0', 'result': 'Hello Python from decorator, ;)'}
+    assert rv.status_code == 200
+
+    data = {'id': 1, 'jsonrpc': '2.0', 'method': 'jsonrpc.decorators', 'params': 'Python'}
+    rv = async_client.post('/api', json=data)
+    assert rv.json == {
+        'id': 1,
+        'jsonrpc': '2.0',
+        'error': {
+            'code': -32602,
+            'data': {'message': 'Parameter structures are by-position (list) or by-name (dict): Python'},
+            'message': 'Invalid params',
+            'name': 'InvalidParamsError',
+        },
+    }
+    assert rv.status_code == 400
+
+    data = {'id': 1, 'jsonrpc': '2.0', 'method': 'jsonrpc.decorators', 'params': [1]}
+    rv = async_client.post('/api', json=data)
+    assert rv.json == {
+        'id': 1,
+        'jsonrpc': '2.0',
+        'error': {
+            'code': -32602,
+            'data': {'message': 'argument "string" (int) is not an instance of str'},
+            'message': 'Invalid params',
+            'name': 'InvalidParamsError',
+        },
+    }
+    assert rv.status_code == 400
+
+
+def test_app_decorators_wrapped(async_client: 'FlaskClient') -> None:
+    data = {'id': 1, 'jsonrpc': '2.0', 'method': 'jsonrpc.decoratorsWrapped', 'params': ['Python']}
+    rv = async_client.post('/api', json=data)
+    assert rv.json == {'id': 1, 'jsonrpc': '2.0', 'result': 'Hello Python from decorator, ;)'}
+    assert rv.status_code == 200
+
+    data = {'id': 1, 'jsonrpc': '2.0', 'method': 'jsonrpc.decoratorsWrapped', 'params': 'Python'}
+    rv = async_client.post('/api', json=data)
+    assert rv.json == {
+        'id': 1,
+        'jsonrpc': '2.0',
+        'error': {
+            'code': -32602,
+            'data': {'message': 'Parameter structures are by-position (list) or by-name (dict): Python'},
+            'message': 'Invalid params',
+            'name': 'InvalidParamsError',
+        },
+    }
+    assert rv.status_code == 400
+
+    # XXX: Typeguard does not instrument wrapped functions
+    data = {'id': 1, 'jsonrpc': '2.0', 'method': 'jsonrpc.decoratorsWrapped', 'params': [1]}
+    rv = async_client.post('/api', json=data)
+    assert rv.json == {'id': 1, 'jsonrpc': '2.0', 'result': 'Hello 1 from decorator, ;)'}
     assert rv.status_code == 200
 
 
@@ -486,7 +544,7 @@ def test_app_with_rcp_batch(async_client: 'FlaskClient') -> None:
     assert rv.status_code == 200
 
 
-def test_app_class(async_client: 'FlaskClient') -> None:
+def _test_app_class(async_client: 'FlaskClient') -> None:
     rv = async_client.post('/api', json={'id': 1, 'jsonrpc': '2.0', 'method': 'classapp.index'})
     assert rv.json == {'id': 1, 'jsonrpc': '2.0', 'result': 'Hello Flask JSON-RPC'}
     assert rv.status_code == 200
@@ -1111,6 +1169,12 @@ def test_app_system_describe(async_client: 'FlaskClient') -> None:
             'options': {'notification': True, 'validate': True},
             'params': [{'name': 'string', 'type': 'String'}],
             'returns': {'type': 'String'},
+        },
+        'jsonrpc.decoratorsWrapped': {
+            'options': {'notification': True, 'validate': True},
+            'params': [{'name': 'string', 'type': 'String'}],
+            'returns': {'type': 'String'},
+            'type': 'method',
         },
         'jsonrpc.returnStatusCode': {
             'type': 'method',

--- a/tests/unit/test_client.py
+++ b/tests/unit/test_client.py
@@ -46,6 +46,19 @@ def test_app_greeting(client: 'FlaskClient') -> None:
     assert rv.json == {'id': 1, 'jsonrpc': '2.0', 'result': 'Hello Flask'}
     assert rv.status_code == 200
 
+    rv = client.post('/api', json={'id': 1, 'jsonrpc': '2.0', 'method': 'jsonrpc.greeting', 'params': {'name': 1}})
+    assert rv.json == {
+        'id': 1,
+        'jsonrpc': '2.0',
+        'error': {
+            'code': -32602,
+            'data': {'message': 'argument "name" (int) is not an instance of str'},
+            'message': 'Invalid params',
+            'name': 'InvalidParamsError',
+        },
+    }
+    assert rv.status_code == 400
+
 
 def test_app_greeting_with_different_content_types(client: 'FlaskClient') -> None:
     rv = client.post(
@@ -169,7 +182,7 @@ def test_app_greeting_raise_invalid_params_error(client: 'FlaskClient') -> None:
         'jsonrpc': '2.0',
         'error': {
             'code': -32602,
-            'data': {'message': 'type of argument "name" must be str; got int instead'},
+            'data': {'message': 'argument "name" (int) is not an instance of str'},
             'message': 'Invalid params',
             'name': 'InvalidParamsError',
         },
@@ -182,7 +195,7 @@ def test_app_greeting_raise_invalid_params_error(client: 'FlaskClient') -> None:
         'jsonrpc': '2.0',
         'error': {
             'code': -32602,
-            'data': {'message': 'type of argument "name" must be str; got int instead'},
+            'data': {'message': 'argument "name" (int) is not an instance of str'},
             'message': 'Invalid params',
             'name': 'InvalidParamsError',
         },
@@ -215,16 +228,13 @@ def test_app_echo(client: 'FlaskClient') -> None:
     assert rv.status_code == 200
 
     rv = client.post('/api', json={'id': 1, 'jsonrpc': '2.0', 'method': 'jsonrpc.echo', 'params': {'string': None}})
-    assert rv.json == {
-        'id': 1,
-        'jsonrpc': '2.0',
-        'error': {
-            'code': -32602,
-            'data': {'message': "missing a required argument: 'string'"},
-            'message': 'Invalid params',
-            'name': 'InvalidParamsError',
-        },
-    }
+    json_data = rv.get_json()
+    assert json_data['id'] == 1
+    assert json_data['jsonrpc'] == '2.0'
+    assert json_data['error']['code'] == -32602
+    assert "missing 1 required positional argument: 'string'" in json_data['error']['data']['message']
+    assert json_data['error']['message'] == 'Invalid params'
+    assert json_data['error']['name'] == 'InvalidParamsError'
     assert rv.status_code == 400
 
 
@@ -248,7 +258,7 @@ def test_app_echo_raise_invalid_params_error(client: 'FlaskClient') -> None:
         'jsonrpc': '2.0',
         'error': {
             'code': -32602,
-            'data': {'message': 'type of argument "string" must be str; got int instead'},
+            'data': {'message': 'argument "string" (int) is not an instance of str'},
             'message': 'Invalid params',
             'name': 'InvalidParamsError',
         },
@@ -256,29 +266,23 @@ def test_app_echo_raise_invalid_params_error(client: 'FlaskClient') -> None:
     assert rv.status_code == 400
 
     rv = client.post('/api', json={'id': 1, 'jsonrpc': '2.0', 'method': 'jsonrpc.echo', 'params': {'name': 2}})
-    assert rv.json == {
-        'id': 1,
-        'jsonrpc': '2.0',
-        'error': {
-            'code': -32602,
-            'data': {'message': "missing a required argument: 'string'"},
-            'message': 'Invalid params',
-            'name': 'InvalidParamsError',
-        },
-    }
+    json_data = rv.get_json()
+    assert json_data['id'] == 1
+    assert json_data['jsonrpc'] == '2.0'
+    assert json_data['error']['code'] == -32602
+    assert "missing 1 required positional argument: 'string'" in json_data['error']['data']['message']
+    assert json_data['error']['message'] == 'Invalid params'
+    assert json_data['error']['name'] == 'InvalidParamsError'
     assert rv.status_code == 400
 
     rv = client.post('/api', json={'id': 1, 'jsonrpc': '2.0', 'method': 'jsonrpc.echo'})
-    assert rv.json == {
-        'id': 1,
-        'jsonrpc': '2.0',
-        'error': {
-            'code': -32602,
-            'data': {'message': "missing a required argument: 'string'"},
-            'message': 'Invalid params',
-            'name': 'InvalidParamsError',
-        },
-    }
+    json_data = rv.get_json()
+    assert json_data['id'] == 1
+    assert json_data['jsonrpc'] == '2.0'
+    assert json_data['error']['code'] == -32602
+    assert "missing 1 required positional argument: 'string'" in json_data['error']['data']['message']
+    assert json_data['error']['message'] == 'Invalid params'
+    assert json_data['error']['name'] == 'InvalidParamsError'
     assert rv.status_code == 400
 
 
@@ -380,16 +384,13 @@ def test_app_sum(client: 'FlaskClient') -> None:
 
     data = {'id': 1, 'jsonrpc': '2.0', 'method': 'jsonrpc.sum', 'params': {'a': None, 'b': None}}
     rv = client.post('/api', json=data)
-    assert rv.json == {
-        'id': 1,
-        'jsonrpc': '2.0',
-        'error': {
-            'code': -32602,
-            'data': {'message': "missing a required argument: 'a'"},
-            'message': 'Invalid params',
-            'name': 'InvalidParamsError',
-        },
-    }
+    json_data = rv.get_json()
+    assert json_data['id'] == 1
+    assert json_data['jsonrpc'] == '2.0'
+    assert json_data['error']['code'] == -32602
+    assert "missing 2 required positional arguments: 'a' and 'b'" in json_data['error']['data']['message']
+    assert json_data['error']['message'] == 'Invalid params'
+    assert json_data['error']['name'] == 'InvalidParamsError'
     assert rv.status_code == 400
 
 
@@ -397,6 +398,61 @@ def test_app_decorators(client: 'FlaskClient') -> None:
     data = {'id': 1, 'jsonrpc': '2.0', 'method': 'jsonrpc.decorators', 'params': ['Python']}
     rv = client.post('/api', json=data)
     assert rv.json == {'id': 1, 'jsonrpc': '2.0', 'result': 'Hello Python from decorator, ;)'}
+    assert rv.status_code == 200
+
+    data = {'id': 1, 'jsonrpc': '2.0', 'method': 'jsonrpc.decorators', 'params': 'Python'}
+    rv = client.post('/api', json=data)
+    assert rv.json == {
+        'id': 1,
+        'jsonrpc': '2.0',
+        'error': {
+            'code': -32602,
+            'data': {'message': 'Parameter structures are by-position (list) or by-name (dict): Python'},
+            'message': 'Invalid params',
+            'name': 'InvalidParamsError',
+        },
+    }
+    assert rv.status_code == 400
+
+    data = {'id': 1, 'jsonrpc': '2.0', 'method': 'jsonrpc.decorators', 'params': [1]}
+    rv = client.post('/api', json=data)
+    assert rv.json == {
+        'id': 1,
+        'jsonrpc': '2.0',
+        'error': {
+            'code': -32602,
+            'data': {'message': 'argument "string" (int) is not an instance of str'},
+            'message': 'Invalid params',
+            'name': 'InvalidParamsError',
+        },
+    }
+    assert rv.status_code == 400
+
+
+def test_app_decorators_wrapped(client: 'FlaskClient') -> None:
+    data = {'id': 1, 'jsonrpc': '2.0', 'method': 'jsonrpc.decoratorsWrapped', 'params': ['Python']}
+    rv = client.post('/api', json=data)
+    assert rv.json == {'id': 1, 'jsonrpc': '2.0', 'result': 'Hello Python from decorator, ;)'}
+    assert rv.status_code == 200
+
+    data = {'id': 1, 'jsonrpc': '2.0', 'method': 'jsonrpc.decoratorsWrapped', 'params': 'Python'}
+    rv = client.post('/api', json=data)
+    assert rv.json == {
+        'id': 1,
+        'jsonrpc': '2.0',
+        'error': {
+            'code': -32602,
+            'data': {'message': 'Parameter structures are by-position (list) or by-name (dict): Python'},
+            'message': 'Invalid params',
+            'name': 'InvalidParamsError',
+        },
+    }
+    assert rv.status_code == 400
+
+    # XXX: Typeguard does not instrument wrapped functions
+    data = {'id': 1, 'jsonrpc': '2.0', 'method': 'jsonrpc.decoratorsWrapped', 'params': [1]}
+    rv = client.post('/api', json=data)
+    assert rv.json == {'id': 1, 'jsonrpc': '2.0', 'result': 'Hello 1 from decorator, ;)'}
     assert rv.status_code == 200
 
 
@@ -1091,6 +1147,12 @@ def test_app_system_describe(client: 'FlaskClient') -> None:
             'options': {'notification': True, 'validate': True},
             'params': [{'name': 'string', 'type': 'String'}],
             'returns': {'type': 'String'},
+        },
+        'jsonrpc.decoratorsWrapped': {
+            'options': {'notification': True, 'validate': True},
+            'params': [{'name': 'string', 'type': 'String'}],
+            'returns': {'type': 'String'},
+            'type': 'method',
         },
         'jsonrpc.returnStatusCode': {
             'type': 'method',

--- a/tests/unit/test_encoders.py
+++ b/tests/unit/test_encoders.py
@@ -31,8 +31,9 @@ from pathlib import Path
 from collections import deque
 from dataclasses import dataclass
 
-import pytest
 from pydantic.main import BaseModel
+
+import pytest
 
 from flask_jsonrpc.encoders import serializable
 

--- a/tests/unit/test_funcutils.py
+++ b/tests/unit/test_funcutils.py
@@ -27,8 +27,9 @@
 import typing as t
 from dataclasses import asdict, dataclass
 
-import pytest
 from pydantic.main import BaseModel
+
+import pytest
 
 from flask_jsonrpc.funcutils import loads
 


### PR DESCRIPTION
The latest Typeguard version (before 3.x) recompiles the target function with added instrumentation, so this result is not unexpected.

* Removed support for class methods in JSON-RPC methods: Issue #319
* Added support for from __future__ import annotations

<!--
## The seven rules of a great Git commit message

:: Keep in mind: This has all been said before.

1. Separate subject from body with a blank line
2. Limit the subject line to 50 characters
3. Capitalize the subject line
4. Do not end the subject line with a period
5. Use the imperative mood in the subject line
6. Wrap the body at 72 characters
7. Use the body to explain what and why vs. how

For example:

```
Summarize changes in around 50 characters or less

More detailed explanatory text, if necessary. Wrap it to about 72
characters or so. In some contexts, the first line is treated as the
subject of the commit and the rest of the text as the body. The
blank line separating the summary from the body is critical (unless
you omit the body entirely); various tools like `log`, `shortlog`
and `rebase` can get confused if you run the two together.

Explain the problem that this commit is solving. Focus on why you
are making this change as opposed to how (the code explains that).
Are there side effects or other unintuitive consequences of this
change? Here's the place to explain them.

Further paragraphs come after blank lines.

 - Bullet points are okay, too

 - Typically a hyphen or asterisk is used for the bullet, preceded
   by a single space, with blank lines in between, but conventions
   vary here

If you use an issue tracker, put references to them at the bottom,
like this:

Resolves: #123
See also: #456, #789
```

More details: https://chris.beams.io/posts/git-commit/.
-->