### PR TITLE
Enable better observability through structured and configurable logging

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -30,7 +30,7 @@ test-cov-unit:
 		if [ $${ALLOW_ASYNC} -eq 0 ] && [[ $${TEST_FILE} == *"async"* ]]; then \
 			continue; \
 		fi; \
-        pytest --cov-reset --cov=$${PY_MODULE} $${TEST_FILE} -vv; \
+        pytest --count 1 -n 0 --cov-reset --cov=$${PY_MODULE} $${TEST_FILE} -vv; \
         if [ $$? -ne 0 ]; then \
             REPORT+=" + Unit Tests $${TEST_FILE} for $${PY_MODULE} failed (pytest --cov-reset --cov-report=html --cov=$${PY_MODULE} $${TEST_FILE} -vv)\n"; \
 		else \

--- a/src/flask_jsonrpc/app.py
+++ b/src/flask_jsonrpc/app.py
@@ -27,12 +27,14 @@
 from __future__ import annotations
 
 import typing as t
+import logging
 from urllib.parse import urlsplit
 
 # Added in version 3.11.
 from typing_extensions import Self
 
 from flask import Flask
+from flask.logging import has_level_handler
 
 from .globals import default_jsonrpc_site, default_jsonrpc_site_api
 from .helpers import urn
@@ -81,6 +83,13 @@ class JSONRPC(JSONRPCDecoratorMixin):
         app_root = app.config['APPLICATION_ROOT']
         url_scheme = app.config['PREFERRED_URL_SCHEME']
         url = urlsplit(self.path)
+
+        if self.logger.level == logging.NOTSET:
+            self.logger.setLevel(app.logger.level)
+
+        if not has_level_handler(self.logger):
+            for handler in app.logger.handlers:
+                self.logger.addHandler(handler)
 
         self.path = f'{app_root.rstrip("/")}{url.path}'
         self.base_url = (

--- a/src/flask_jsonrpc/views.py
+++ b/src/flask_jsonrpc/views.py
@@ -31,7 +31,7 @@ import typing as t
 # Added in version 3.11.
 from typing_extensions import Self
 
-from flask import typing as ft, current_app, make_response
+from flask import typing as ft, make_response
 from flask.views import MethodView
 
 from .site import JSONRPC_VERSION_DEFAULT, JSONRPC_DEFAULT_HTTP_HEADERS
@@ -53,6 +53,6 @@ class JSONRPCView(MethodView):
                 return make_response('', status_code, headers)
             return make_response(jsonify(response), status_code, headers)
         except JSONRPCError as e:
-            current_app.logger.exception('jsonrpc error')
+            self.jsonrpc_site.logger.info('jsonrpc error', exc_info=e)
             response = {'id': None, 'jsonrpc': JSONRPC_VERSION_DEFAULT, 'error': e.jsonrpc_format}
             return make_response(jsonify(response), e.status_code, JSONRPC_DEFAULT_HTTP_HEADERS)

--- a/src/flask_jsonrpc/wrappers.py
+++ b/src/flask_jsonrpc/wrappers.py
@@ -28,6 +28,7 @@ from __future__ import annotations
 
 import typing as t
 from inspect import Parameter, _empty, signature, isfunction
+import logging
 import functools
 from collections import OrderedDict
 
@@ -37,6 +38,7 @@ import typing_inspect
 from typing_extensions import Self
 
 from typeguard import typechecked
+from werkzeug.utils import cached_property
 
 from .settings import settings
 from .types.methods import MethodAnnotated
@@ -128,6 +130,11 @@ class JSONRPCDecoratorMixin:
             functools.update_wrapper(fn_wrapper, fn_wrapped)
             fn_wrapped = fn_wrapper
         return fn_wrapper
+
+    @cached_property
+    def logger(self: Self) -> logging.Logger:
+        logger = logging.getLogger('flask_jsonrpc')
+        return logger
 
     def get_jsonrpc_site(self: Self) -> JSONRPCSite:
         raise NotImplementedError('.get_jsonrpc_site must be overridden') from None

--- a/tests/unit/test_app.py
+++ b/tests/unit/test_app.py
@@ -26,9 +26,11 @@
 # POSSIBILITY OF SUCH DAMAGE.
 import uuid
 import typing as t
+import logging
 from unittest import mock
 
 from flask import Flask, json
+from flask.logging import default_handler
 
 import pytest
 from werkzeug.datastructures import Headers
@@ -40,6 +42,37 @@ try:
     from typing import Self
 except ImportError:  # pragma: no cover
     from typing_extensions import Self
+
+
+@pytest.fixture(autouse=True)
+def reset_logging(pytestconfig: pytest.Config) -> t.Generator[None, None, None]:
+    root_handlers = logging.root.handlers[:]
+    logging.root.handlers = []
+    root_level = logging.root.level
+
+    flask_logger = logging.getLogger('test_app')
+    flask_logger.handlers = []
+    flask_logger.setLevel(logging.NOTSET)
+
+    logger = logging.getLogger('flask_jsonrpc')
+    logger.handlers = []
+    logger.setLevel(logging.NOTSET)
+
+    logging_plugin = pytestconfig.pluginmanager.unregister(name='logging-plugin')
+
+    yield
+
+    logging.root.handlers[:] = root_handlers
+    logging.root.setLevel(root_level)
+
+    flask_logger.handlers = []
+    flask_logger.setLevel(logging.NOTSET)
+
+    logger.handlers = []
+    logger.setLevel(logging.NOTSET)
+
+    if logging_plugin:
+        pytestconfig.pluginmanager.register(logging_plugin, 'logging-plugin')
 
 
 class CustomException(Exception):
@@ -141,6 +174,56 @@ def test_app_create() -> None:
         )
         assert rv.json == {'id': 1, 'jsonrpc': '2.0', 'result': 'Welcome to Flask JSON-RPC'}
         assert rv.status_code == 200
+
+
+def test_app_create_with_default_logger() -> None:
+    app = Flask('test_app', instance_relative_config=True)
+    jsonrpc = JSONRPC(app, '/api', enable_web_browsable_api=True)
+
+    @jsonrpc.method('app.index')
+    def index() -> str:
+        return 'Welcome to Flask JSON-RPC'
+
+    with app.test_client() as client:
+        rv = client.post('/api', json={'id': 1, 'jsonrpc': '2.0', 'method': 'app.index', 'params': []})
+        assert rv.json == {'id': 1, 'jsonrpc': '2.0', 'result': 'Welcome to Flask JSON-RPC'}
+        assert rv.status_code == 200
+
+    assert app.logger.name == 'test_app'
+    assert app.logger.level == logging.NOTSET
+    assert app.logger.handlers == [default_handler]
+
+    assert jsonrpc.logger.name == 'flask_jsonrpc'
+    assert jsonrpc.logger.level == logging.NOTSET
+    assert jsonrpc.logger.handlers == [default_handler]
+
+
+def test_app_create_with_custom_logger() -> None:
+    logger_handler = logging.StreamHandler()
+    logger = logging.getLogger('flask_jsonrpc')
+    _ = [logger.removeHandler(handler) for handler in logger.handlers]
+    logger.addHandler(logger_handler)
+    logger.setLevel(logging.DEBUG)
+
+    app = Flask('test_app', instance_relative_config=True)
+    jsonrpc = JSONRPC(app, '/api', enable_web_browsable_api=True)
+
+    @jsonrpc.method('app.index')
+    def index() -> str:
+        return 'Welcome to Flask JSON-RPC'
+
+    with app.test_client() as client:
+        rv = client.post('/api', json={'id': 1, 'jsonrpc': '2.0', 'method': 'app.index', 'params': []})
+        assert rv.json == {'id': 1, 'jsonrpc': '2.0', 'result': 'Welcome to Flask JSON-RPC'}
+        assert rv.status_code == 200
+
+    assert app.logger.name == 'test_app'
+    assert app.logger.level == logging.NOTSET
+    assert app.logger.handlers == [default_handler]
+
+    assert jsonrpc.logger.name == 'flask_jsonrpc'
+    assert jsonrpc.logger.level == logging.DEBUG
+    assert jsonrpc.logger.handlers == [logger_handler]
 
 
 def test_app_create_using_error_handler() -> None:

--- a/tests/unit/test_views.py
+++ b/tests/unit/test_views.py
@@ -25,6 +25,7 @@
 # ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
 import typing as t
+import logging
 
 from flask import Flask
 
@@ -40,6 +41,9 @@ except ImportError:  # pragma: no cover
 
 def test_jsonrpc_view_simple() -> None:
     class MockJSONRPCSite:
+        def __init__(self: Self) -> None:
+            self.logger = logging.getLogger('mock_jsonrpc_site')
+
         def dispatch_request(self: Self) -> tuple[t.Any, int, dict[str, t.Any]]:
             return {'id': 1, 'jsonrpc': '2.0', 'result': 'Hello world!'}, 200, {}
 
@@ -54,6 +58,9 @@ def test_jsonrpc_view_simple() -> None:
 
 def test_jsonrpc_view_with_response_status_code_204() -> None:
     class MockJSONRPCSite:
+        def __init__(self: Self) -> None:
+            self.logger = logging.getLogger('mock_jsonrpc_site')
+
         def dispatch_request(self: Self) -> tuple[t.Any, int, dict[str, t.Any]]:
             return '', 204, {}
 
@@ -68,6 +75,9 @@ def test_jsonrpc_view_with_response_status_code_204() -> None:
 
 def test_jsonrpc_view_with_invalid_request() -> None:
     class MockJSONRPCSite:
+        def __init__(self: Self) -> None:
+            self.logger = logging.getLogger('mock_jsonrpc_site')
+
         def dispatch_request(self: Self) -> tuple[t.Any, int, dict[str, t.Any]]:
             raise JSONRPCError(
                 message='Invalid request', code=1001, data={'message': 'Invalid request'}, status_code=500

--- a/tests/unit/test_wrappers.py
+++ b/tests/unit/test_wrappers.py
@@ -25,6 +25,7 @@
 # ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
 import typing as t
+import logging
 from functools import wraps
 
 import pytest
@@ -57,6 +58,14 @@ class JSONRPCApp(JSONRPCDecoratorMixin):
 
     def get_jsonrpc_site_api(self: Self) -> type[JSONRPCView]:
         raise NotImplementedError('.get_jsonrpc_site_api must be overridden') from None
+
+
+def test_logger() -> None:
+    jsonrpc_app = JSONRPCApp()
+    logger = jsonrpc_app.logger
+    assert logger.name == 'flask_jsonrpc'
+    assert logger.level == logging.NOTSET
+    assert logger.handlers == []
 
 
 def test_jsonrpc_register_view_function_simple() -> None:


### PR DESCRIPTION
Introduces a **flexible and consistent logging approach** for **Flask-JSONRPC**, inspired by Flask’s own logging system. The goal is to provide better control, visibility, and integration with external logging tools while maintaining compatibility with Flask’s conventions.

---

* Adds a dedicated logger named `flask_jsonrpc` following [Flask’s logging conventions](https://flask.palletsprojects.com/en/stable/logging/).
* All logs emitted by Flask-JSONRPC will use either the `INFO` or `DEBUG` levels.
* This allows client applications to decide whether to enable, suppress, or redirect logs to external systems. → See [Flask: Other Libraries Logging](https://flask.palletsprojects.com/en/stable/logging/#other-libraries).

---

* If the user does **not** configure logging, Flask-JSONRPC automatically adds a [StreamHandler](https://docs.python.org/3/library/logging.handlers.html#logging.StreamHandler) to [app.logger](https://flask.palletsprojects.com/en/stable/api/#flask.Flask.logger).
* During requests, logs go to `environ['wsgi.errors']` (usually [sys.stderr](https://docs.python.org/3/library/sys.html#sys.stderr)).
* Outside of requests, logs are written directly to `sys.stderr`.

If logging is configured after accessing `app.logger`, the default handler can be removed as follows:

```python
from flask.logging import default_handler
app.logger.removeHandler(default_handler)
```

---

See: [Flask Logging – Basic Configuration](https://flask.palletsprojects.com/en/stable/logging/#basic-configuration)

```python
logger = logging.getLogger('flask_jsonrpc')
logger.addHandler(logging.StreamHandler())
logger.setLevel(logging.DEBUG)

app = Flask('test_app', instance_relative_config=True)
jsonrpc = JSONRPC(app, '/api', enable_web_browsable_api=True)
```

```python
logger = logging.getLogger('custom_logger')
logger.addHandler(logging.StreamHandler())
logger.setLevel(logging.DEBUG)

app = Flask('site')
jsonrpc_site = JSONRPCSite(version='1.0.0', path='/path', base_url='/base')
jsonrpc_site.logger = logger
```

This provides flexibility for developers to customize how logs are handled and where they are sent.

---

* In **DEBUG mode**, exceptions now include additional diagnostic data such as stack traces and the Python executable path.
* Example implementation:

```python
@property
def jsonrpc_format(self: Self) -> dict[str, t.Any]:
    """Return the Exception data in JSON-RPC format."""
    error = {
        'name': self.__class__.__name__,
        'code': self.code,
        'message': self.message,
        'data': self.data
    }

    if current_app and current_app.config['DEBUG']:
        error['stack'] = traceback.format_exc()
        error['executable'] = sys.executable

    return error
```

---

* Combines structured error handling, global error hooks, and flexible logging configuration.
* Gives clients full control to manage exceptions, customize logs, and integrate with monitoring or observability tools.

Resolves: #646
See also: #647

<!--
## The seven rules of a great Git commit message

:: Keep in mind: This has all been said before.

1. Separate subject from body with a blank line
2. Limit the subject line to 50 characters
3. Capitalize the subject line
4. Do not end the subject line with a period
5. Use the imperative mood in the subject line
6. Wrap the body at 72 characters
7. Use the body to explain what and why vs. how

For example:

```
Summarize changes in around 50 characters or less

More detailed explanatory text, if necessary. Wrap it to about 72
characters or so. In some contexts, the first line is treated as the
subject of the commit and the rest of the text as the body. The
blank line separating the summary from the body is critical (unless
you omit the body entirely); various tools like `log`, `shortlog`
and `rebase` can get confused if you run the two together.

Explain the problem that this commit is solving. Focus on why you
are making this change as opposed to how (the code explains that).
Are there side effects or other unintuitive consequences of this
change? Here's the place to explain them.

Further paragraphs come after blank lines.

 - Bullet points are okay, too

 - Typically a hyphen or asterisk is used for the bullet, preceded
   by a single space, with blank lines in between, but conventions
   vary here

If you use an issue tracker, put references to them at the bottom,
like this:

Resolves: #123
See also: #456, #789
```

More details: https://chris.beams.io/posts/git-commit/.
-->