### PR TITLE
Fix type checker for optional function parameter without default value

### DIFF
--- a/.github/workflows/on_update.yml
+++ b/.github/workflows/on_update.yml
@@ -36,13 +36,13 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
           allow-prereleases: true
-      - run: |
-          RUN_PARALLEL=("3.14" "3.14t")
-          if [[ "${RUN_PARALLEL[@]}" =~ "${{ matrix.python-version }}" ]]; then
-            uv run --locked --group tests tox run -e py,py-async
-          else
-            uv run --locked --group tests tox run -e py,py-async -- --parallel-threads=0 --iterations=0
-          fi
+      - name: Run tests in parallel
+        if: ${{ matrix.python-version == '3.14' || matrix.python-version == '3.14t' }}
+        run: |
+          uv run --locked --group tests tox run -e py,py-async
+      - name: Run tests in serial
+        run: |
+          uv run --locked --group tests tox run -e py,py-async -- --parallel-threads=0 --iterations=0
 
   typing:
     name: Type checker [${{ matrix.platform }} | ${{ matrix.python-version }}]

--- a/src/flask_jsonrpc/site.py
+++ b/src/flask_jsonrpc/site.py
@@ -166,8 +166,7 @@ class JSONRPCSite:
             if validate:
                 binded_params = type_checker(view_func, binded_params)
 
-            sanitazed_params = {k: v for k, v in binded_params.items() if v is not None}
-            resp_view = current_app.ensure_sync(view_func)(**sanitazed_params)
+            resp_view = current_app.ensure_sync(view_func)(**binded_params)
 
             # TODO: Enhance the checker to return the type
             view_fun_annotations = t.get_type_hints(view_func) if validate else {}

--- a/tests/integration/test_browse_app.py
+++ b/tests/integration/test_browse_app.py
@@ -68,7 +68,7 @@ def test_app_echo_display(
             {
                 'error': {
                     'code': -32602,
-                    'data': {'message': "create_app..echo() missing 1 required positional argument: 'string'"},
+                    'data': {'message': 'argument "string" (None) is not an instance of str'},
                     'message': 'Invalid params',
                     'name': 'InvalidParamsError',
                 },
@@ -291,17 +291,7 @@ def test_app_wrapped_decorators_display(
         (
             {'string': ''},
             {'jsonrpc': '2.0', 'method': 'app.wrappedDecorators', 'params': {}},
-            {
-                'error': {
-                    'code': -32602,
-                    'data': {
-                        'message': "create_app..wrapped_decorators() missing 1 required positional argument: 'string'"
-                    },
-                    'message': 'Invalid params',
-                    'name': 'InvalidParamsError',
-                },
-                'jsonrpc': '2.0',
-            },
+            {'jsonrpc': '2.0', 'result': 'Hello None from decorator, ;)'},
         ),
     ],
 )

--- a/tests/integration/test_browse_class_apps.py
+++ b/tests/integration/test_browse_class_apps.py
@@ -213,7 +213,7 @@ def test_class_apps_echo_display(
             {
                 'error': {
                     'code': -32602,
-                    'data': {'message': "App.echo() missing 1 required positional argument: 'string'"},
+                    'data': {'message': 'argument "string" (None) is not an instance of str'},
                     'message': 'Invalid params',
                     'name': 'InvalidParamsError',
                 },

--- a/tests/integration/test_browse_decorators.py
+++ b/tests/integration/test_browse_decorators.py
@@ -75,9 +75,7 @@ def test_decorators_decorator_display(
             {
                 'error': {
                     'code': -32602,
-                    'data': {
-                        'message': "jsonrpc_decorator..decorator() missing 1 required positional argument: 'string'"
-                    },
+                    'data': {'message': 'argument "string" (None) is not an instance of str'},
                     'message': 'Invalid params',
                     'name': 'InvalidParamsError',
                 },
@@ -142,15 +140,7 @@ def test_decorators_wrapped_decorator_display(
         (
             {'string': ''},
             {'jsonrpc': '2.0', 'method': 'decorators.wrappedDecorator', 'params': {}},
-            {
-                'error': {
-                    'code': -32602,
-                    'data': {'message': "wrappedDecorator() missing 1 required positional argument: 'string'"},
-                    'message': 'Invalid params',
-                    'name': 'InvalidParamsError',
-                },
-                'jsonrpc': '2.0',
-            },
+            {'jsonrpc': '2.0', 'result': 'Hello None from decorator, ;)'},
         ),
         (
             {'string': 'Functools'},

--- a/tests/integration/test_browse_jsonrpc_basic.py
+++ b/tests/integration/test_browse_jsonrpc_basic.py
@@ -70,7 +70,7 @@ def test_jsonrpc_basic_echo_display(
             {
                 'error': {
                     'code': -32602,
-                    'data': {'message': "echo() missing 1 required positional argument: 'string'"},
+                    'data': {'message': 'argument "string" (None) is not an instance of str'},
                     'message': 'Invalid params',
                     'name': 'InvalidParamsError',
                 },
@@ -489,12 +489,7 @@ def test_jsonrpc_basic_strange_echo_display(
             {
                 'error': {
                     'code': -32602,
-                    'data': {
-                        'message': (
-                            'strange_echo() missing 4 required positional'
-                            " arguments: 'string', 'omg', 'wtf', and 'nowai'"
-                        )
-                    },
+                    'data': {'message': ('argument "string" (None) is not an instance of str')},
                     'message': 'Invalid params',
                     'name': 'InvalidParamsError',
                 },

--- a/tests/integration/test_browse_python_stds.py
+++ b/tests/integration/test_browse_python_stds.py
@@ -125,7 +125,7 @@ def test_types_python_stds_str_type_display(
             {
                 'error': {
                     'code': -32602,
-                    'data': {'message': "str_type() missing 1 required positional argument: 'st'"},
+                    'data': {'message': 'argument "st" (None) is not an instance of str'},
                     'message': 'Invalid params',
                     'name': 'InvalidParamsError',
                 },
@@ -469,7 +469,7 @@ def test_types_python_bytes_type_display(
             {
                 'error': {
                     'code': -32602,
-                    'data': {'message': "bytes_type() missing 1 required positional argument: 'b'"},
+                    'data': {'message': 'argument "b" (None) is not bytes-like'},
                     'message': 'Invalid params',
                     'name': 'InvalidParamsError',
                 },
@@ -545,7 +545,7 @@ def test_types_python_bytearray_type_display(
             {
                 'error': {
                     'code': -32602,
-                    'data': {'message': "bytearray_type() missing 1 required positional argument: 'b'"},
+                    'data': {'message': 'argument "b" (None) is not an instance of bytearray'},
                     'message': 'Invalid params',
                     'name': 'InvalidParamsError',
                 },
@@ -626,6 +626,22 @@ def test_types_python_int_enum_type_display(
             {'e': 3},
             {'jsonrpc': '2.0', 'method': 'types.python_stds.intEnumType', 'params': {'e': 3}},
             {'jsonrpc': '2.0', 'result': 3},
+        ),
+        (
+            {'e': ''},
+            {'jsonrpc': '2.0', 'method': 'types.python_stds.intEnumType', 'params': {}},
+            {
+                'error': {
+                    'code': -32602,
+                    'data': {
+                        'message': 'argument "e" (None) is not an instance of '
+                        'shared.features.types.python_stds.ColorIntEnum'
+                    },
+                    'message': 'Invalid params',
+                    'name': 'InvalidParamsError',
+                },
+                'jsonrpc': '2.0',
+            },
         ),
     ],
 )

--- a/tests/shared/test_apps/features/test_jsonrpc_basic.py
+++ b/tests/shared/test_apps/features/test_jsonrpc_basic.py
@@ -53,7 +53,7 @@ def test_app_echo(session: 'Session', api_url: str) -> None:
     assert json_data['id'] == 1
     assert json_data['jsonrpc'] == '2.0'
     assert json_data['error']['code'] == -32602
-    assert "missing 1 required positional argument: 'string'" in json_data['error']['data']['message']
+    assert 'argument "string" (None) is not an instance of str' in json_data['error']['data']['message']
     assert json_data['error']['message'] == 'Invalid params'
     assert json_data['error']['name'] == 'InvalidParamsError'
     assert rv.status_code == 400
@@ -98,7 +98,7 @@ def test_app_echo_raise_invalid_params_error(session: 'Session', api_url: str) -
     assert json_data['id'] == 1
     assert json_data['jsonrpc'] == '2.0'
     assert json_data['error']['code'] == -32602
-    assert "missing 1 required positional argument: 'string'" in json_data['error']['data']['message']
+    assert 'argument "string" (None) is not an instance of str' in json_data['error']['data']['message']
     assert json_data['error']['message'] == 'Invalid params'
     assert json_data['error']['name'] == 'InvalidParamsError'
     assert rv.status_code == 400
@@ -108,7 +108,7 @@ def test_app_echo_raise_invalid_params_error(session: 'Session', api_url: str) -
     assert json_data['id'] == 1
     assert json_data['jsonrpc'] == '2.0'
     assert json_data['error']['code'] == -32602
-    assert "missing 1 required positional argument: 'string'" in json_data['error']['data']['message']
+    assert 'argument "string" (None) is not an instance of str' in json_data['error']['data']['message']
     assert json_data['error']['message'] == 'Invalid params'
     assert json_data['error']['name'] == 'InvalidParamsError'
     assert rv.status_code == 400
@@ -223,7 +223,7 @@ def test_app_sum(session: 'Session', api_url: str) -> None:
     assert json_data['id'] == 1
     assert json_data['jsonrpc'] == '2.0'
     assert json_data['error']['code'] == -32602
-    assert "missing 2 required positional arguments: 'a' and 'b'" in json_data['error']['data']['message']
+    assert 'argument "a" (None) is neither float or int' in json_data['error']['data']['message']
     assert json_data['error']['message'] == 'Invalid params'
     assert json_data['error']['name'] == 'InvalidParamsError'
     assert rv.status_code == 400
@@ -390,6 +390,14 @@ def test_app_system_describe(session: 'Session', api_url: str) -> None:
             'type': 'method',
             'validation': True,
         },
+        'jsonrpc_basic.optionalParamWithoutDefaultValue': {
+            'name': 'jsonrpc_basic.optionalParamWithoutDefaultValue',
+            'notification': True,
+            'params': [{'name': 'string', 'type': 'String'}],
+            'returns': {'name': 'default', 'type': 'String'},
+            'type': 'method',
+            'validation': True,
+        },
         'jsonrpc_basic.returnHeaders': {
             'name': 'jsonrpc_basic.returnHeaders',
             'notification': True,
@@ -459,3 +467,48 @@ def test_app_system_describe(session: 'Session', api_url: str) -> None:
             'validation': False,
         },
     }
+
+
+def test_app_optional_param_without_default_value(session: 'Session', api_url: str) -> None:
+    rv = session.post(
+        f'{api_url}/jsonrpc-basic',
+        json={
+            'id': 1,
+            'jsonrpc': '2.0',
+            'method': 'jsonrpc_basic.optionalParamWithoutDefaultValue',
+            'params': ['Python'],
+        },
+    )
+    assert rv.json() == {'id': 1, 'jsonrpc': '2.0', 'result': 'Python'}
+    assert rv.status_code == 200
+
+    rv = session.post(
+        f'{api_url}/jsonrpc-basic',
+        json={
+            'id': 1,
+            'jsonrpc': '2.0',
+            'method': 'jsonrpc_basic.optionalParamWithoutDefaultValue',
+            'params': {'string': 'Flask'},
+        },
+    )
+    assert rv.json() == {'id': 1, 'jsonrpc': '2.0', 'result': 'Flask'}
+    assert rv.status_code == 200
+
+    rv = session.post(
+        f'{api_url}/jsonrpc-basic',
+        json={
+            'id': 1,
+            'jsonrpc': '2.0',
+            'method': 'jsonrpc_basic.optionalParamWithoutDefaultValue',
+            'params': {'string': None},
+        },
+    )
+    assert rv.json() == {'id': 1, 'jsonrpc': '2.0', 'result': None}
+    assert rv.status_code == 200
+
+    rv = session.post(
+        f'{api_url}/jsonrpc-basic',
+        json={'id': 1, 'jsonrpc': '2.0', 'method': 'jsonrpc_basic.optionalParamWithoutDefaultValue', 'params': {}},
+    )
+    assert rv.json() == {'id': 1, 'jsonrpc': '2.0', 'result': None}
+    assert rv.status_code == 200

--- a/tests/shared/test_apps/test_async_app.py
+++ b/tests/shared/test_apps/test_async_app.py
@@ -245,7 +245,7 @@ def test_app_echo(async_session: 'Session', api_url: str) -> None:
     assert json_data['id'] == 1
     assert json_data['jsonrpc'] == '2.0'
     assert json_data['error']['code'] == -32602
-    assert "missing 1 required positional argument: 'string'" in json_data['error']['data']['message']
+    assert 'argument "string" (None) is not an instance of str' in json_data['error']['data']['message']
     assert json_data['error']['message'] == 'Invalid params'
     assert json_data['error']['name'] == 'InvalidParamsError'
     assert rv.status_code == 400
@@ -283,7 +283,7 @@ def test_app_echo_raise_invalid_params_error(async_session: 'Session', api_url: 
     assert json_data['id'] == 1
     assert json_data['jsonrpc'] == '2.0'
     assert json_data['error']['code'] == -32602
-    assert "missing 1 required positional argument: 'string'" in json_data['error']['data']['message']
+    assert 'argument "string" (None) is not an instance of str' in json_data['error']['data']['message']
     assert json_data['error']['message'] == 'Invalid params'
     assert json_data['error']['name'] == 'InvalidParamsError'
     assert rv.status_code == 400
@@ -293,7 +293,7 @@ def test_app_echo_raise_invalid_params_error(async_session: 'Session', api_url: 
     assert json_data['id'] == 1
     assert json_data['jsonrpc'] == '2.0'
     assert json_data['error']['code'] == -32602
-    assert "missing 1 required positional argument: 'string'" in json_data['error']['data']['message']
+    assert 'argument "string" (None) is not an instance of str' in json_data['error']['data']['message']
     assert json_data['error']['message'] == 'Invalid params'
     assert json_data['error']['name'] == 'InvalidParamsError'
     assert rv.status_code == 400

--- a/tests/test_apps/shared/features/jsonrpc_basic.py
+++ b/tests/test_apps/shared/features/jsonrpc_basic.py
@@ -98,3 +98,8 @@ def mixin_not_validate(s, t: int, u, v: str, x, z):  # noqa: ANN001,ANN202,ANN20
 @jsonrpc.method('jsonrpc_basic.noReturn')
 def no_return(_string: str | None = None) -> t.NoReturn:
     raise ValueError('no return')
+
+
+@jsonrpc.method('jsonrpc_basic.optionalParamWithoutDefaultValue')
+def optional_param_without_default_value(string: str | None) -> str | None:
+    return string


### PR DESCRIPTION
Remove the sanitization of function parameters when the value is None.

Resolve: #661

<!--
## The seven rules of a great Git commit message

:: Keep in mind: This has all been said before.

1. Separate subject from body with a blank line
2. Limit the subject line to 50 characters
3. Capitalize the subject line
4. Do not end the subject line with a period
5. Use the imperative mood in the subject line
6. Wrap the body at 72 characters
7. Use the body to explain what and why vs. how

For example:

```
Summarize changes in around 50 characters or less

More detailed explanatory text, if necessary. Wrap it to about 72
characters or so. In some contexts, the first line is treated as the
subject of the commit and the rest of the text as the body. The
blank line separating the summary from the body is critical (unless
you omit the body entirely); various tools like `log`, `shortlog`
and `rebase` can get confused if you run the two together.

Explain the problem that this commit is solving. Focus on why you
are making this change as opposed to how (the code explains that).
Are there side effects or other unintuitive consequences of this
change? Here's the place to explain them.

Further paragraphs come after blank lines.

 - Bullet points are okay, too

 - Typically a hyphen or asterisk is used for the bullet, preceded
   by a single space, with blank lines in between, but conventions
   vary here

If you use an issue tracker, put references to them at the bottom,
like this:

Resolves: #123
See also: #456, #789
```

More details: https://chris.beams.io/posts/git-commit/.
-->