### PR TITLE
Auto-fill Default Parameter Values in Browse API

### DIFF
--- a/examples/javascript/uv.lock
+++ b/examples/javascript/uv.lock
@@ -247,7 +247,7 @@ async = [
 
 [[package]]
 name = "flask-jsonrpc"
-version = "4.0.0a15"
+version = "4.0.0a16"
 source = { editable = "../../" }
 dependencies = [
     { name = "annotated-types" },
@@ -274,7 +274,7 @@ requires-dist = [
 provides-extras = ["async", "dotenv"]
 
 [package.metadata.requires-dev]
-build = [{ name = "hatch", specifier = "==1.15.1" }]
+build = [{ name = "hatch", specifier = "==1.16.1" }]
 cbuild = [
     { name = "cibuildwheel", marker = "python_full_version >= '3.11'", specifier = "==3.2.0" },
     { name = "hatch-mypyc", specifier = "==0.16.0" },
@@ -284,7 +284,7 @@ cbuild = [
 ]
 ci-tests = [
     { name = "coverage", extras = ["toml"], specifier = "==7.12.0" },
-    { name = "pytest", specifier = "==8.4.2" },
+    { name = "pytest", specifier = "==9.0.1" },
     { name = "pytest-clarity", specifier = "==1.0.1" },
     { name = "pytest-cov", specifier = "==7.0.0" },
     { name = "pytest-env", specifier = "==1.2.0" },
@@ -311,8 +311,8 @@ docs = [
 ]
 integration-tests = [
     { name = "coverage", extras = ["toml"], specifier = "==7.12.0" },
-    { name = "playwright", specifier = "==1.55.0" },
-    { name = "pytest", specifier = "==8.4.2" },
+    { name = "playwright", specifier = "==1.56.0" },
+    { name = "pytest", specifier = "==9.0.1" },
     { name = "pytest-clarity", specifier = "==1.0.1" },
     { name = "pytest-cov", specifier = "==7.0.0" },
     { name = "pytest-env", specifier = "==1.2.0" },
@@ -328,7 +328,7 @@ integration-tests = [
 ]
 parallel-tests = [
     { name = "coverage", extras = ["toml"], specifier = "==7.12.0" },
-    { name = "pytest", specifier = "==8.4.2" },
+    { name = "pytest", specifier = "==9.0.1" },
     { name = "pytest-clarity", specifier = "==1.0.1" },
     { name = "pytest-cov", specifier = "==7.0.0" },
     { name = "pytest-env", specifier = "==1.2.0" },
@@ -336,7 +336,7 @@ parallel-tests = [
     { name = "pytest-randomly", specifier = "==4.0.1" },
     { name = "pytest-repeat", specifier = "==0.9.4" },
     { name = "pytest-rerunfailures", specifier = "==16.1" },
-    { name = "pytest-run-parallel", specifier = "==0.7.1" },
+    { name = "pytest-run-parallel", specifier = "==0.8.0" },
     { name = "pytest-sugar", specifier = "==1.1.1" },
     { name = "pytest-xdist", specifier = "==3.8.0" },
     { name = "requests", specifier = "==2.32.5" },
@@ -350,7 +350,7 @@ security = [{ name = "bandit", marker = "python_full_version >= '3.11'" }]
 style = [{ name = "ruff", specifier = "==0.14.6" }]
 tests = [
     { name = "coverage", extras = ["toml"], specifier = "==7.12.0" },
-    { name = "pytest", specifier = "==8.4.2" },
+    { name = "pytest", specifier = "==9.0.1" },
     { name = "pytest-clarity", specifier = "==1.0.1" },
     { name = "pytest-cov", specifier = "==7.0.0" },
     { name = "pytest-env", specifier = "==1.2.0" },
@@ -973,12 +973,12 @@ wheels = [
 
 [[package]]
 name = "werkzeug"
-version = "3.1.3"
+version = "3.1.4"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "markupsafe" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/9f/69/83029f1f6300c5fb2471d621ab06f6ec6b3324685a2ce0f9777fd4a8b71e/werkzeug-3.1.3.tar.gz", hash = "sha256:60723ce945c19328679790e3282cc758aa4a6040e4bb330f53d30fa546d44746", size = 806925, upload-time = "2024-11-08T15:52:18.093Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/45/ea/b0f8eeb287f8df9066e56e831c7824ac6bab645dd6c7a8f4b2d767944f9b/werkzeug-3.1.4.tar.gz", hash = "sha256:cd3cd98b1b92dc3b7b3995038826c68097dcb16f9baa63abe35f20eafeb9fe5e", size = 864687, upload-time = "2025-11-29T02:15:22.841Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/52/24/ab44c871b0f07f491e5d2ad12c9bd7358e527510618cb1b803a88e986db1/werkzeug-3.1.3-py3-none-any.whl", hash = "sha256:54b78bf3716d19a65be4fceccc0d1d7b89e608834989dfae50ea87564639213e", size = 224498, upload-time = "2024-11-08T15:52:16.132Z" },
+    { url = "https://files.pythonhosted.org/packages/2f/f9/9e082990c2585c744734f85bec79b5dae5df9c974ffee58fe421652c8e91/werkzeug-3.1.4-py3-none-any.whl", hash = "sha256:2ad50fb9ed09cc3af22c54698351027ace879a0b60a3b5edf5730b2f7d876905", size = 224960, upload-time = "2025-11-29T02:15:21.13Z" },
 ]

--- a/examples/minimal-async/uv.lock
+++ b/examples/minimal-async/uv.lock
@@ -247,7 +247,7 @@ async = [
 
 [[package]]
 name = "flask-jsonrpc"
-version = "4.0.0a15"
+version = "4.0.0a16"
 source = { editable = "../../" }
 dependencies = [
     { name = "annotated-types" },
@@ -274,7 +274,7 @@ requires-dist = [
 provides-extras = ["async", "dotenv"]
 
 [package.metadata.requires-dev]
-build = [{ name = "hatch", specifier = "==1.15.1" }]
+build = [{ name = "hatch", specifier = "==1.16.1" }]
 cbuild = [
     { name = "cibuildwheel", marker = "python_full_version >= '3.11'", specifier = "==3.2.0" },
     { name = "hatch-mypyc", specifier = "==0.16.0" },
@@ -284,7 +284,7 @@ cbuild = [
 ]
 ci-tests = [
     { name = "coverage", extras = ["toml"], specifier = "==7.12.0" },
-    { name = "pytest", specifier = "==8.4.2" },
+    { name = "pytest", specifier = "==9.0.1" },
     { name = "pytest-clarity", specifier = "==1.0.1" },
     { name = "pytest-cov", specifier = "==7.0.0" },
     { name = "pytest-env", specifier = "==1.2.0" },
@@ -311,8 +311,8 @@ docs = [
 ]
 integration-tests = [
     { name = "coverage", extras = ["toml"], specifier = "==7.12.0" },
-    { name = "playwright", specifier = "==1.55.0" },
-    { name = "pytest", specifier = "==8.4.2" },
+    { name = "playwright", specifier = "==1.56.0" },
+    { name = "pytest", specifier = "==9.0.1" },
     { name = "pytest-clarity", specifier = "==1.0.1" },
     { name = "pytest-cov", specifier = "==7.0.0" },
     { name = "pytest-env", specifier = "==1.2.0" },
@@ -328,7 +328,7 @@ integration-tests = [
 ]
 parallel-tests = [
     { name = "coverage", extras = ["toml"], specifier = "==7.12.0" },
-    { name = "pytest", specifier = "==8.4.2" },
+    { name = "pytest", specifier = "==9.0.1" },
     { name = "pytest-clarity", specifier = "==1.0.1" },
     { name = "pytest-cov", specifier = "==7.0.0" },
     { name = "pytest-env", specifier = "==1.2.0" },
@@ -336,7 +336,7 @@ parallel-tests = [
     { name = "pytest-randomly", specifier = "==4.0.1" },
     { name = "pytest-repeat", specifier = "==0.9.4" },
     { name = "pytest-rerunfailures", specifier = "==16.1" },
-    { name = "pytest-run-parallel", specifier = "==0.7.1" },
+    { name = "pytest-run-parallel", specifier = "==0.8.0" },
     { name = "pytest-sugar", specifier = "==1.1.1" },
     { name = "pytest-xdist", specifier = "==3.8.0" },
     { name = "requests", specifier = "==2.32.5" },
@@ -350,7 +350,7 @@ security = [{ name = "bandit", marker = "python_full_version >= '3.11'" }]
 style = [{ name = "ruff", specifier = "==0.14.6" }]
 tests = [
     { name = "coverage", extras = ["toml"], specifier = "==7.12.0" },
-    { name = "pytest", specifier = "==8.4.2" },
+    { name = "pytest", specifier = "==9.0.1" },
     { name = "pytest-clarity", specifier = "==1.0.1" },
     { name = "pytest-cov", specifier = "==7.0.0" },
     { name = "pytest-env", specifier = "==1.2.0" },
@@ -975,12 +975,12 @@ wheels = [
 
 [[package]]
 name = "werkzeug"
-version = "3.1.3"
+version = "3.1.4"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "markupsafe" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/9f/69/83029f1f6300c5fb2471d621ab06f6ec6b3324685a2ce0f9777fd4a8b71e/werkzeug-3.1.3.tar.gz", hash = "sha256:60723ce945c19328679790e3282cc758aa4a6040e4bb330f53d30fa546d44746", size = 806925, upload-time = "2024-11-08T15:52:18.093Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/45/ea/b0f8eeb287f8df9066e56e831c7824ac6bab645dd6c7a8f4b2d767944f9b/werkzeug-3.1.4.tar.gz", hash = "sha256:cd3cd98b1b92dc3b7b3995038826c68097dcb16f9baa63abe35f20eafeb9fe5e", size = 864687, upload-time = "2025-11-29T02:15:22.841Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/52/24/ab44c871b0f07f491e5d2ad12c9bd7358e527510618cb1b803a88e986db1/werkzeug-3.1.3-py3-none-any.whl", hash = "sha256:54b78bf3716d19a65be4fceccc0d1d7b89e608834989dfae50ea87564639213e", size = 224498, upload-time = "2024-11-08T15:52:16.132Z" },
+    { url = "https://files.pythonhosted.org/packages/2f/f9/9e082990c2585c744734f85bec79b5dae5df9c974ffee58fe421652c8e91/werkzeug-3.1.4-py3-none-any.whl", hash = "sha256:2ad50fb9ed09cc3af22c54698351027ace879a0b60a3b5edf5730b2f7d876905", size = 224960, upload-time = "2025-11-29T02:15:21.13Z" },
 ]

--- a/examples/minimal/uv.lock
+++ b/examples/minimal/uv.lock
@@ -247,7 +247,7 @@ async = [
 
 [[package]]
 name = "flask-jsonrpc"
-version = "4.0.0a15"
+version = "4.0.0a16"
 source = { editable = "../../" }
 dependencies = [
     { name = "annotated-types" },
@@ -274,7 +274,7 @@ requires-dist = [
 provides-extras = ["async", "dotenv"]
 
 [package.metadata.requires-dev]
-build = [{ name = "hatch", specifier = "==1.15.1" }]
+build = [{ name = "hatch", specifier = "==1.16.1" }]
 cbuild = [
     { name = "cibuildwheel", marker = "python_full_version >= '3.11'", specifier = "==3.2.0" },
     { name = "hatch-mypyc", specifier = "==0.16.0" },
@@ -284,7 +284,7 @@ cbuild = [
 ]
 ci-tests = [
     { name = "coverage", extras = ["toml"], specifier = "==7.12.0" },
-    { name = "pytest", specifier = "==8.4.2" },
+    { name = "pytest", specifier = "==9.0.1" },
     { name = "pytest-clarity", specifier = "==1.0.1" },
     { name = "pytest-cov", specifier = "==7.0.0" },
     { name = "pytest-env", specifier = "==1.2.0" },
@@ -311,8 +311,8 @@ docs = [
 ]
 integration-tests = [
     { name = "coverage", extras = ["toml"], specifier = "==7.12.0" },
-    { name = "playwright", specifier = "==1.55.0" },
-    { name = "pytest", specifier = "==8.4.2" },
+    { name = "playwright", specifier = "==1.56.0" },
+    { name = "pytest", specifier = "==9.0.1" },
     { name = "pytest-clarity", specifier = "==1.0.1" },
     { name = "pytest-cov", specifier = "==7.0.0" },
     { name = "pytest-env", specifier = "==1.2.0" },
@@ -328,7 +328,7 @@ integration-tests = [
 ]
 parallel-tests = [
     { name = "coverage", extras = ["toml"], specifier = "==7.12.0" },
-    { name = "pytest", specifier = "==8.4.2" },
+    { name = "pytest", specifier = "==9.0.1" },
     { name = "pytest-clarity", specifier = "==1.0.1" },
     { name = "pytest-cov", specifier = "==7.0.0" },
     { name = "pytest-env", specifier = "==1.2.0" },
@@ -336,7 +336,7 @@ parallel-tests = [
     { name = "pytest-randomly", specifier = "==4.0.1" },
     { name = "pytest-repeat", specifier = "==0.9.4" },
     { name = "pytest-rerunfailures", specifier = "==16.1" },
-    { name = "pytest-run-parallel", specifier = "==0.7.1" },
+    { name = "pytest-run-parallel", specifier = "==0.8.0" },
     { name = "pytest-sugar", specifier = "==1.1.1" },
     { name = "pytest-xdist", specifier = "==3.8.0" },
     { name = "requests", specifier = "==2.32.5" },
@@ -350,7 +350,7 @@ security = [{ name = "bandit", marker = "python_full_version >= '3.11'" }]
 style = [{ name = "ruff", specifier = "==0.14.6" }]
 tests = [
     { name = "coverage", extras = ["toml"], specifier = "==7.12.0" },
-    { name = "pytest", specifier = "==8.4.2" },
+    { name = "pytest", specifier = "==9.0.1" },
     { name = "pytest-clarity", specifier = "==1.0.1" },
     { name = "pytest-cov", specifier = "==7.0.0" },
     { name = "pytest-env", specifier = "==1.2.0" },
@@ -973,12 +973,12 @@ wheels = [
 
 [[package]]
 name = "werkzeug"
-version = "3.1.3"
+version = "3.1.4"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "markupsafe" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/9f/69/83029f1f6300c5fb2471d621ab06f6ec6b3324685a2ce0f9777fd4a8b71e/werkzeug-3.1.3.tar.gz", hash = "sha256:60723ce945c19328679790e3282cc758aa4a6040e4bb330f53d30fa546d44746", size = 806925, upload-time = "2024-11-08T15:52:18.093Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/45/ea/b0f8eeb287f8df9066e56e831c7824ac6bab645dd6c7a8f4b2d767944f9b/werkzeug-3.1.4.tar.gz", hash = "sha256:cd3cd98b1b92dc3b7b3995038826c68097dcb16f9baa63abe35f20eafeb9fe5e", size = 864687, upload-time = "2025-11-29T02:15:22.841Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/52/24/ab44c871b0f07f491e5d2ad12c9bd7358e527510618cb1b803a88e986db1/werkzeug-3.1.3-py3-none-any.whl", hash = "sha256:54b78bf3716d19a65be4fceccc0d1d7b89e608834989dfae50ea87564639213e", size = 224498, upload-time = "2024-11-08T15:52:16.132Z" },
+    { url = "https://files.pythonhosted.org/packages/2f/f9/9e082990c2585c744734f85bec79b5dae5df9c974ffee58fe421652c8e91/werkzeug-3.1.4-py3-none-any.whl", hash = "sha256:2ad50fb9ed09cc3af22c54698351027ace879a0b60a3b5edf5730b2f7d876905", size = 224960, upload-time = "2025-11-29T02:15:21.13Z" },
 ]

--- a/examples/modular/uv.lock
+++ b/examples/modular/uv.lock
@@ -247,7 +247,7 @@ async = [
 
 [[package]]
 name = "flask-jsonrpc"
-version = "4.0.0a15"
+version = "4.0.0a16"
 source = { editable = "../../" }
 dependencies = [
     { name = "annotated-types" },
@@ -274,7 +274,7 @@ requires-dist = [
 provides-extras = ["async", "dotenv"]
 
 [package.metadata.requires-dev]
-build = [{ name = "hatch", specifier = "==1.15.1" }]
+build = [{ name = "hatch", specifier = "==1.16.1" }]
 cbuild = [
     { name = "cibuildwheel", marker = "python_full_version >= '3.11'", specifier = "==3.2.0" },
     { name = "hatch-mypyc", specifier = "==0.16.0" },
@@ -284,7 +284,7 @@ cbuild = [
 ]
 ci-tests = [
     { name = "coverage", extras = ["toml"], specifier = "==7.12.0" },
-    { name = "pytest", specifier = "==8.4.2" },
+    { name = "pytest", specifier = "==9.0.1" },
     { name = "pytest-clarity", specifier = "==1.0.1" },
     { name = "pytest-cov", specifier = "==7.0.0" },
     { name = "pytest-env", specifier = "==1.2.0" },
@@ -311,8 +311,8 @@ docs = [
 ]
 integration-tests = [
     { name = "coverage", extras = ["toml"], specifier = "==7.12.0" },
-    { name = "playwright", specifier = "==1.55.0" },
-    { name = "pytest", specifier = "==8.4.2" },
+    { name = "playwright", specifier = "==1.56.0" },
+    { name = "pytest", specifier = "==9.0.1" },
     { name = "pytest-clarity", specifier = "==1.0.1" },
     { name = "pytest-cov", specifier = "==7.0.0" },
     { name = "pytest-env", specifier = "==1.2.0" },
@@ -328,7 +328,7 @@ integration-tests = [
 ]
 parallel-tests = [
     { name = "coverage", extras = ["toml"], specifier = "==7.12.0" },
-    { name = "pytest", specifier = "==8.4.2" },
+    { name = "pytest", specifier = "==9.0.1" },
     { name = "pytest-clarity", specifier = "==1.0.1" },
     { name = "pytest-cov", specifier = "==7.0.0" },
     { name = "pytest-env", specifier = "==1.2.0" },
@@ -336,7 +336,7 @@ parallel-tests = [
     { name = "pytest-randomly", specifier = "==4.0.1" },
     { name = "pytest-repeat", specifier = "==0.9.4" },
     { name = "pytest-rerunfailures", specifier = "==16.1" },
-    { name = "pytest-run-parallel", specifier = "==0.7.1" },
+    { name = "pytest-run-parallel", specifier = "==0.8.0" },
     { name = "pytest-sugar", specifier = "==1.1.1" },
     { name = "pytest-xdist", specifier = "==3.8.0" },
     { name = "requests", specifier = "==2.32.5" },
@@ -350,7 +350,7 @@ security = [{ name = "bandit", marker = "python_full_version >= '3.11'" }]
 style = [{ name = "ruff", specifier = "==0.14.6" }]
 tests = [
     { name = "coverage", extras = ["toml"], specifier = "==7.12.0" },
-    { name = "pytest", specifier = "==8.4.2" },
+    { name = "pytest", specifier = "==9.0.1" },
     { name = "pytest-clarity", specifier = "==1.0.1" },
     { name = "pytest-cov", specifier = "==7.0.0" },
     { name = "pytest-env", specifier = "==1.2.0" },
@@ -973,12 +973,12 @@ wheels = [
 
 [[package]]
 name = "werkzeug"
-version = "3.1.3"
+version = "3.1.4"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "markupsafe" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/9f/69/83029f1f6300c5fb2471d621ab06f6ec6b3324685a2ce0f9777fd4a8b71e/werkzeug-3.1.3.tar.gz", hash = "sha256:60723ce945c19328679790e3282cc758aa4a6040e4bb330f53d30fa546d44746", size = 806925, upload-time = "2024-11-08T15:52:18.093Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/45/ea/b0f8eeb287f8df9066e56e831c7824ac6bab645dd6c7a8f4b2d767944f9b/werkzeug-3.1.4.tar.gz", hash = "sha256:cd3cd98b1b92dc3b7b3995038826c68097dcb16f9baa63abe35f20eafeb9fe5e", size = 864687, upload-time = "2025-11-29T02:15:22.841Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/52/24/ab44c871b0f07f491e5d2ad12c9bd7358e527510618cb1b803a88e986db1/werkzeug-3.1.3-py3-none-any.whl", hash = "sha256:54b78bf3716d19a65be4fceccc0d1d7b89e608834989dfae50ea87564639213e", size = 224498, upload-time = "2024-11-08T15:52:16.132Z" },
+    { url = "https://files.pythonhosted.org/packages/2f/f9/9e082990c2585c744734f85bec79b5dae5df9c974ffee58fe421652c8e91/werkzeug-3.1.4-py3-none-any.whl", hash = "sha256:2ad50fb9ed09cc3af22c54698351027ace879a0b60a3b5edf5730b2f7d876905", size = 224960, upload-time = "2025-11-29T02:15:21.13Z" },
 ]

--- a/examples/multiplesite/uv.lock
+++ b/examples/multiplesite/uv.lock
@@ -247,7 +247,7 @@ async = [
 
 [[package]]
 name = "flask-jsonrpc"
-version = "4.0.0a15"
+version = "4.0.0a16"
 source = { editable = "../../" }
 dependencies = [
     { name = "annotated-types" },
@@ -274,7 +274,7 @@ requires-dist = [
 provides-extras = ["async", "dotenv"]
 
 [package.metadata.requires-dev]
-build = [{ name = "hatch", specifier = "==1.15.1" }]
+build = [{ name = "hatch", specifier = "==1.16.1" }]
 cbuild = [
     { name = "cibuildwheel", marker = "python_full_version >= '3.11'", specifier = "==3.2.0" },
     { name = "hatch-mypyc", specifier = "==0.16.0" },
@@ -284,7 +284,7 @@ cbuild = [
 ]
 ci-tests = [
     { name = "coverage", extras = ["toml"], specifier = "==7.12.0" },
-    { name = "pytest", specifier = "==8.4.2" },
+    { name = "pytest", specifier = "==9.0.1" },
     { name = "pytest-clarity", specifier = "==1.0.1" },
     { name = "pytest-cov", specifier = "==7.0.0" },
     { name = "pytest-env", specifier = "==1.2.0" },
@@ -311,8 +311,8 @@ docs = [
 ]
 integration-tests = [
     { name = "coverage", extras = ["toml"], specifier = "==7.12.0" },
-    { name = "playwright", specifier = "==1.55.0" },
-    { name = "pytest", specifier = "==8.4.2" },
+    { name = "playwright", specifier = "==1.56.0" },
+    { name = "pytest", specifier = "==9.0.1" },
     { name = "pytest-clarity", specifier = "==1.0.1" },
     { name = "pytest-cov", specifier = "==7.0.0" },
     { name = "pytest-env", specifier = "==1.2.0" },
@@ -328,7 +328,7 @@ integration-tests = [
 ]
 parallel-tests = [
     { name = "coverage", extras = ["toml"], specifier = "==7.12.0" },
-    { name = "pytest", specifier = "==8.4.2" },
+    { name = "pytest", specifier = "==9.0.1" },
     { name = "pytest-clarity", specifier = "==1.0.1" },
     { name = "pytest-cov", specifier = "==7.0.0" },
     { name = "pytest-env", specifier = "==1.2.0" },
@@ -336,7 +336,7 @@ parallel-tests = [
     { name = "pytest-randomly", specifier = "==4.0.1" },
     { name = "pytest-repeat", specifier = "==0.9.4" },
     { name = "pytest-rerunfailures", specifier = "==16.1" },
-    { name = "pytest-run-parallel", specifier = "==0.7.1" },
+    { name = "pytest-run-parallel", specifier = "==0.8.0" },
     { name = "pytest-sugar", specifier = "==1.1.1" },
     { name = "pytest-xdist", specifier = "==3.8.0" },
     { name = "requests", specifier = "==2.32.5" },
@@ -350,7 +350,7 @@ security = [{ name = "bandit", marker = "python_full_version >= '3.11'" }]
 style = [{ name = "ruff", specifier = "==0.14.6" }]
 tests = [
     { name = "coverage", extras = ["toml"], specifier = "==7.12.0" },
-    { name = "pytest", specifier = "==8.4.2" },
+    { name = "pytest", specifier = "==9.0.1" },
     { name = "pytest-clarity", specifier = "==1.0.1" },
     { name = "pytest-cov", specifier = "==7.0.0" },
     { name = "pytest-env", specifier = "==1.2.0" },
@@ -973,12 +973,12 @@ wheels = [
 
 [[package]]
 name = "werkzeug"
-version = "3.1.3"
+version = "3.1.4"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "markupsafe" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/9f/69/83029f1f6300c5fb2471d621ab06f6ec6b3324685a2ce0f9777fd4a8b71e/werkzeug-3.1.3.tar.gz", hash = "sha256:60723ce945c19328679790e3282cc758aa4a6040e4bb330f53d30fa546d44746", size = 806925, upload-time = "2024-11-08T15:52:18.093Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/45/ea/b0f8eeb287f8df9066e56e831c7824ac6bab645dd6c7a8f4b2d767944f9b/werkzeug-3.1.4.tar.gz", hash = "sha256:cd3cd98b1b92dc3b7b3995038826c68097dcb16f9baa63abe35f20eafeb9fe5e", size = 864687, upload-time = "2025-11-29T02:15:22.841Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/52/24/ab44c871b0f07f491e5d2ad12c9bd7358e527510618cb1b803a88e986db1/werkzeug-3.1.3-py3-none-any.whl", hash = "sha256:54b78bf3716d19a65be4fceccc0d1d7b89e608834989dfae50ea87564639213e", size = 224498, upload-time = "2024-11-08T15:52:16.132Z" },
+    { url = "https://files.pythonhosted.org/packages/2f/f9/9e082990c2585c744734f85bec79b5dae5df9c974ffee58fe421652c8e91/werkzeug-3.1.4-py3-none-any.whl", hash = "sha256:2ad50fb9ed09cc3af22c54698351027ace879a0b60a3b5edf5730b2f7d876905", size = 224960, upload-time = "2025-11-29T02:15:21.13Z" },
 ]

--- a/examples/openrpc/uv.lock
+++ b/examples/openrpc/uv.lock
@@ -247,7 +247,7 @@ async = [
 
 [[package]]
 name = "flask-jsonrpc"
-version = "4.0.0a15"
+version = "4.0.0a16"
 source = { editable = "../../" }
 dependencies = [
     { name = "annotated-types" },
@@ -274,7 +274,7 @@ requires-dist = [
 provides-extras = ["async", "dotenv"]
 
 [package.metadata.requires-dev]
-build = [{ name = "hatch", specifier = "==1.15.1" }]
+build = [{ name = "hatch", specifier = "==1.16.1" }]
 cbuild = [
     { name = "cibuildwheel", marker = "python_full_version >= '3.11'", specifier = "==3.2.0" },
     { name = "hatch-mypyc", specifier = "==0.16.0" },
@@ -284,7 +284,7 @@ cbuild = [
 ]
 ci-tests = [
     { name = "coverage", extras = ["toml"], specifier = "==7.12.0" },
-    { name = "pytest", specifier = "==8.4.2" },
+    { name = "pytest", specifier = "==9.0.1" },
     { name = "pytest-clarity", specifier = "==1.0.1" },
     { name = "pytest-cov", specifier = "==7.0.0" },
     { name = "pytest-env", specifier = "==1.2.0" },
@@ -311,8 +311,8 @@ docs = [
 ]
 integration-tests = [
     { name = "coverage", extras = ["toml"], specifier = "==7.12.0" },
-    { name = "playwright", specifier = "==1.55.0" },
-    { name = "pytest", specifier = "==8.4.2" },
+    { name = "playwright", specifier = "==1.56.0" },
+    { name = "pytest", specifier = "==9.0.1" },
     { name = "pytest-clarity", specifier = "==1.0.1" },
     { name = "pytest-cov", specifier = "==7.0.0" },
     { name = "pytest-env", specifier = "==1.2.0" },
@@ -328,7 +328,7 @@ integration-tests = [
 ]
 parallel-tests = [
     { name = "coverage", extras = ["toml"], specifier = "==7.12.0" },
-    { name = "pytest", specifier = "==8.4.2" },
+    { name = "pytest", specifier = "==9.0.1" },
     { name = "pytest-clarity", specifier = "==1.0.1" },
     { name = "pytest-cov", specifier = "==7.0.0" },
     { name = "pytest-env", specifier = "==1.2.0" },
@@ -336,7 +336,7 @@ parallel-tests = [
     { name = "pytest-randomly", specifier = "==4.0.1" },
     { name = "pytest-repeat", specifier = "==0.9.4" },
     { name = "pytest-rerunfailures", specifier = "==16.1" },
-    { name = "pytest-run-parallel", specifier = "==0.7.1" },
+    { name = "pytest-run-parallel", specifier = "==0.8.0" },
     { name = "pytest-sugar", specifier = "==1.1.1" },
     { name = "pytest-xdist", specifier = "==3.8.0" },
     { name = "requests", specifier = "==2.32.5" },
@@ -350,7 +350,7 @@ security = [{ name = "bandit", marker = "python_full_version >= '3.11'" }]
 style = [{ name = "ruff", specifier = "==0.14.6" }]
 tests = [
     { name = "coverage", extras = ["toml"], specifier = "==7.12.0" },
-    { name = "pytest", specifier = "==8.4.2" },
+    { name = "pytest", specifier = "==9.0.1" },
     { name = "pytest-clarity", specifier = "==1.0.1" },
     { name = "pytest-cov", specifier = "==7.0.0" },
     { name = "pytest-env", specifier = "==1.2.0" },
@@ -973,12 +973,12 @@ wheels = [
 
 [[package]]
 name = "werkzeug"
-version = "3.1.3"
+version = "3.1.4"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "markupsafe" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/9f/69/83029f1f6300c5fb2471d621ab06f6ec6b3324685a2ce0f9777fd4a8b71e/werkzeug-3.1.3.tar.gz", hash = "sha256:60723ce945c19328679790e3282cc758aa4a6040e4bb330f53d30fa546d44746", size = 806925, upload-time = "2024-11-08T15:52:18.093Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/45/ea/b0f8eeb287f8df9066e56e831c7824ac6bab645dd6c7a8f4b2d767944f9b/werkzeug-3.1.4.tar.gz", hash = "sha256:cd3cd98b1b92dc3b7b3995038826c68097dcb16f9baa63abe35f20eafeb9fe5e", size = 864687, upload-time = "2025-11-29T02:15:22.841Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/52/24/ab44c871b0f07f491e5d2ad12c9bd7358e527510618cb1b803a88e986db1/werkzeug-3.1.3-py3-none-any.whl", hash = "sha256:54b78bf3716d19a65be4fceccc0d1d7b89e608834989dfae50ea87564639213e", size = 224498, upload-time = "2024-11-08T15:52:16.132Z" },
+    { url = "https://files.pythonhosted.org/packages/2f/f9/9e082990c2585c744734f85bec79b5dae5df9c974ffee58fe421652c8e91/werkzeug-3.1.4-py3-none-any.whl", hash = "sha256:2ad50fb9ed09cc3af22c54698351027ace879a0b60a3b5edf5730b2f7d876905", size = 224960, upload-time = "2025-11-29T02:15:21.13Z" },
 ]

--- a/examples/rpcdescribe/uv.lock
+++ b/examples/rpcdescribe/uv.lock
@@ -247,7 +247,7 @@ async = [
 
 [[package]]
 name = "flask-jsonrpc"
-version = "4.0.0a15"
+version = "4.0.0a16"
 source = { editable = "../../" }
 dependencies = [
     { name = "annotated-types" },
@@ -274,7 +274,7 @@ requires-dist = [
 provides-extras = ["async", "dotenv"]
 
 [package.metadata.requires-dev]
-build = [{ name = "hatch", specifier = "==1.15.1" }]
+build = [{ name = "hatch", specifier = "==1.16.1" }]
 cbuild = [
     { name = "cibuildwheel", marker = "python_full_version >= '3.11'", specifier = "==3.2.0" },
     { name = "hatch-mypyc", specifier = "==0.16.0" },
@@ -284,7 +284,7 @@ cbuild = [
 ]
 ci-tests = [
     { name = "coverage", extras = ["toml"], specifier = "==7.12.0" },
-    { name = "pytest", specifier = "==8.4.2" },
+    { name = "pytest", specifier = "==9.0.1" },
     { name = "pytest-clarity", specifier = "==1.0.1" },
     { name = "pytest-cov", specifier = "==7.0.0" },
     { name = "pytest-env", specifier = "==1.2.0" },
@@ -311,8 +311,8 @@ docs = [
 ]
 integration-tests = [
     { name = "coverage", extras = ["toml"], specifier = "==7.12.0" },
-    { name = "playwright", specifier = "==1.55.0" },
-    { name = "pytest", specifier = "==8.4.2" },
+    { name = "playwright", specifier = "==1.56.0" },
+    { name = "pytest", specifier = "==9.0.1" },
     { name = "pytest-clarity", specifier = "==1.0.1" },
     { name = "pytest-cov", specifier = "==7.0.0" },
     { name = "pytest-env", specifier = "==1.2.0" },
@@ -328,7 +328,7 @@ integration-tests = [
 ]
 parallel-tests = [
     { name = "coverage", extras = ["toml"], specifier = "==7.12.0" },
-    { name = "pytest", specifier = "==8.4.2" },
+    { name = "pytest", specifier = "==9.0.1" },
     { name = "pytest-clarity", specifier = "==1.0.1" },
     { name = "pytest-cov", specifier = "==7.0.0" },
     { name = "pytest-env", specifier = "==1.2.0" },
@@ -336,7 +336,7 @@ parallel-tests = [
     { name = "pytest-randomly", specifier = "==4.0.1" },
     { name = "pytest-repeat", specifier = "==0.9.4" },
     { name = "pytest-rerunfailures", specifier = "==16.1" },
-    { name = "pytest-run-parallel", specifier = "==0.7.1" },
+    { name = "pytest-run-parallel", specifier = "==0.8.0" },
     { name = "pytest-sugar", specifier = "==1.1.1" },
     { name = "pytest-xdist", specifier = "==3.8.0" },
     { name = "requests", specifier = "==2.32.5" },
@@ -350,7 +350,7 @@ security = [{ name = "bandit", marker = "python_full_version >= '3.11'" }]
 style = [{ name = "ruff", specifier = "==0.14.6" }]
 tests = [
     { name = "coverage", extras = ["toml"], specifier = "==7.12.0" },
-    { name = "pytest", specifier = "==8.4.2" },
+    { name = "pytest", specifier = "==9.0.1" },
     { name = "pytest-clarity", specifier = "==1.0.1" },
     { name = "pytest-cov", specifier = "==7.0.0" },
     { name = "pytest-env", specifier = "==1.2.0" },
@@ -973,12 +973,12 @@ wheels = [
 
 [[package]]
 name = "werkzeug"
-version = "3.1.3"
+version = "3.1.4"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "markupsafe" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/9f/69/83029f1f6300c5fb2471d621ab06f6ec6b3324685a2ce0f9777fd4a8b71e/werkzeug-3.1.3.tar.gz", hash = "sha256:60723ce945c19328679790e3282cc758aa4a6040e4bb330f53d30fa546d44746", size = 806925, upload-time = "2024-11-08T15:52:18.093Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/45/ea/b0f8eeb287f8df9066e56e831c7824ac6bab645dd6c7a8f4b2d767944f9b/werkzeug-3.1.4.tar.gz", hash = "sha256:cd3cd98b1b92dc3b7b3995038826c68097dcb16f9baa63abe35f20eafeb9fe5e", size = 864687, upload-time = "2025-11-29T02:15:22.841Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/52/24/ab44c871b0f07f491e5d2ad12c9bd7358e527510618cb1b803a88e986db1/werkzeug-3.1.3-py3-none-any.whl", hash = "sha256:54b78bf3716d19a65be4fceccc0d1d7b89e608834989dfae50ea87564639213e", size = 224498, upload-time = "2024-11-08T15:52:16.132Z" },
+    { url = "https://files.pythonhosted.org/packages/2f/f9/9e082990c2585c744734f85bec79b5dae5df9c974ffee58fe421652c8e91/werkzeug-3.1.4-py3-none-any.whl", hash = "sha256:2ad50fb9ed09cc3af22c54698351027ace879a0b60a3b5edf5730b2f7d876905", size = 224960, upload-time = "2025-11-29T02:15:21.13Z" },
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "Flask-JSONRPC"
-version = "4.0.0a15"
+version = "4.0.0a16"
 description = "Adds JSONRPC support to Flask."
 readme = {file = "README.md", content-type = "text/markdown"}
 license = {file = "LICENSE.txt"}

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -102,8 +102,12 @@ def jsonrpc_call(page_session: t.Callable[..., Page]) -> t.Generator[t.Callable[
         response_expected: dict[str, t.Any],
     ) -> Page:
         page = page_session(jsonrpc_method)
+        page.wait_for_selector('input[type=text], textarea')
+        fields = page.locator('input[type=text]')
+        for i in range(fields.count()):
+            fields.nth(i).fill('', force=True)
         for name, value in test_input.items():
-            page.fill(f'input[name="{name}"]', value if isinstance(value, str) else json.dumps(value))
+            page.fill(f'input[name="{name}"]', value if isinstance(value, str) else json.dumps(value), force=True)
         page.get_by_role('button', name='Run', exact=True).click()
 
         request_element = page.locator('.request-content')

--- a/uv.lock
+++ b/uv.lock
@@ -26,17 +26,16 @@ wheels = [
 
 [[package]]
 name = "anyio"
-version = "4.11.0"
+version = "4.12.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "exceptiongroup", marker = "python_full_version < '3.11'" },
     { name = "idna" },
-    { name = "sniffio" },
     { name = "typing-extensions", marker = "python_full_version < '3.13'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/c6/78/7d432127c41b50bccba979505f272c16cbcadcc33645d5fa3a738110ae75/anyio-4.11.0.tar.gz", hash = "sha256:82a8d0b81e318cc5ce71a5f1f8b5c4e63619620b63141ef8c995fa0db95a57c4", size = 219094, upload-time = "2025-09-23T09:19:12.58Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/16/ce/8a777047513153587e5434fd752e89334ac33e379aa3497db860eeb60377/anyio-4.12.0.tar.gz", hash = "sha256:73c693b567b0c55130c104d0b43a9baf3aa6a31fc6110116509f27bf75e21ec0", size = 228266, upload-time = "2025-11-28T23:37:38.911Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/15/b3/9b1a8074496371342ec1e796a96f99c82c945a339cd81a8e73de28b4cf9e/anyio-4.11.0-py3-none-any.whl", hash = "sha256:0287e96f4d26d4149305414d4e3bc32f0dcd0862365a4bddea19d7a1ec38c4fc", size = 109097, upload-time = "2025-09-23T09:19:10.601Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/9c/36c5c37947ebfb8c7f22e0eb6e4d188ee2d53aa3880f3f2744fb894f0cb1/anyio-4.12.0-py3-none-any.whl", hash = "sha256:dad2376a628f98eeca4881fc56cd06affd18f659b17a747d3ff0307ced94b1bb", size = 113362, upload-time = "2025-11-28T23:36:57.897Z" },
 ]
 
 [[package]]
@@ -718,7 +717,7 @@ dotenv = [
 
 [[package]]
 name = "flask-jsonrpc"
-version = "4.0.0a15"
+version = "4.0.0a16"
 source = { editable = "." }
 dependencies = [
     { name = "annotated-types" },
@@ -2269,15 +2268,6 @@ wheels = [
 ]
 
 [[package]]
-name = "sniffio"
-version = "1.3.1"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/a2/87/a6771e1546d97e7e041b6ae58d80074f81b7d5121207425c964ddf5cfdbd/sniffio-1.3.1.tar.gz", hash = "sha256:f4324edc670a0f49750a81b895f35c3adb843cca46f0530f79fc1babb23789dc", size = 20372, upload-time = "2024-02-25T23:20:04.057Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/e9/44/75a9c9421471a6c4805dbf2356f7c181a29c1879239abab1ea2cc8f38b40/sniffio-1.3.1-py3-none-any.whl", hash = "sha256:2f6da418d1f1e0fddd844478f41680e794e6051915791a034ff65e5f100525a2", size = 10235, upload-time = "2024-02-25T23:20:01.196Z" },
-]
-
-[[package]]
 name = "snowballstemmer"
 version = "3.0.1"
 source = { registry = "https://pypi.org/simple" }
@@ -2709,14 +2699,14 @@ wheels = [
 
 [[package]]
 name = "werkzeug"
-version = "3.1.3"
+version = "3.1.4"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "markupsafe" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/9f/69/83029f1f6300c5fb2471d621ab06f6ec6b3324685a2ce0f9777fd4a8b71e/werkzeug-3.1.3.tar.gz", hash = "sha256:60723ce945c19328679790e3282cc758aa4a6040e4bb330f53d30fa546d44746", size = 806925, upload-time = "2024-11-08T15:52:18.093Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/45/ea/b0f8eeb287f8df9066e56e831c7824ac6bab645dd6c7a8f4b2d767944f9b/werkzeug-3.1.4.tar.gz", hash = "sha256:cd3cd98b1b92dc3b7b3995038826c68097dcb16f9baa63abe35f20eafeb9fe5e", size = 864687, upload-time = "2025-11-29T02:15:22.841Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/52/24/ab44c871b0f07f491e5d2ad12c9bd7358e527510618cb1b803a88e986db1/werkzeug-3.1.3-py3-none-any.whl", hash = "sha256:54b78bf3716d19a65be4fceccc0d1d7b89e608834989dfae50ea87564639213e", size = 224498, upload-time = "2024-11-08T15:52:16.132Z" },
+    { url = "https://files.pythonhosted.org/packages/2f/f9/9e082990c2585c744734f85bec79b5dae5df9c974ffee58fe421652c8e91/werkzeug-3.1.4-py3-none-any.whl", hash = "sha256:2ad50fb9ed09cc3af22c54698351027ace879a0b60a3b5edf5730b2f7d876905", size = 224960, upload-time = "2025-11-29T02:15:21.13Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Add automatic population of default parameter values in the Web Browsable API dialog, making it easier for developers to test and explore JSON-RPC methods with pre-filled example values.

Resolves: #372

<!--
## The seven rules of a great Git commit message

:: Keep in mind: This has all been said before.

1. Separate subject from body with a blank line
2. Limit the subject line to 50 characters
3. Capitalize the subject line
4. Do not end the subject line with a period
5. Use the imperative mood in the subject line
6. Wrap the body at 72 characters
7. Use the body to explain what and why vs. how

For example:

```
Summarize changes in around 50 characters or less

More detailed explanatory text, if necessary. Wrap it to about 72
characters or so. In some contexts, the first line is treated as the
subject of the commit and the rest of the text as the body. The
blank line separating the summary from the body is critical (unless
you omit the body entirely); various tools like `log`, `shortlog`
and `rebase` can get confused if you run the two together.

Explain the problem that this commit is solving. Focus on why you
are making this change as opposed to how (the code explains that).
Are there side effects or other unintuitive consequences of this
change? Here's the place to explain them.

Further paragraphs come after blank lines.

 - Bullet points are okay, too

 - Typically a hyphen or asterisk is used for the bullet, preceded
   by a single space, with blank lines in between, but conventions
   vary here

If you use an issue tracker, put references to them at the bottom,
like this:

Resolves: #123
See also: #456, #789
```

More details: https://chris.beams.io/posts/git-commit/.
-->