### PR TITLE
Add Middleware System for Flask-JSONRPC Browse

### DIFF
--- a/examples/rpcdescribe/pyproject.toml
+++ b/examples/rpcdescribe/pyproject.toml
@@ -7,7 +7,10 @@ license = {file = "LICENSE.txt"}
 authors = [{name = "Nycholas Oliveira", email = "nycholas@cenobit.es"}]
 maintainers = [{name = "Cenobit Technologies Inc.", email = "hi@cenobit.es"}]
 requires-python = ">=3.10"
-dependencies = ["Flask-JSONRPC"]
+dependencies = [
+    "Flask-JSONRPC",
+    "flask-jwt-extended>=4.7.1",
+]
 
 [project.optional-dependencies]
 async = ["Flask[async]>=3.0.0,<4.0"]

--- a/examples/rpcdescribe/src/petstore/static/css/login.css
+++ b/examples/rpcdescribe/src/petstore/static/css/login.css
@@ -1,0 +1,170 @@
+body {
+    margin: 0;
+    padding: 0;
+    font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
+    background-color: #f0f2f5;
+    color: #333;
+}
+
+.login-container {
+    min-height: 100vh;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
+}
+
+.login-card {
+    background: white;
+    border-radius: 16px;
+    box-shadow: 0 20px 60px rgba(0, 0, 0, 0.3);
+    width: 100%;
+    max-width: 420px;
+    overflow: hidden;
+}
+
+.login-header {
+    background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
+    color: white;
+    padding: 40px 30px;
+    text-align: center;
+}
+
+.login-header h1 {
+    margin: 0 0 10px 0;
+    font-size: 2em;
+    font-weight: 700;
+}
+
+.login-header p {
+    margin: 0;
+    opacity: 0.9;
+    font-size: 1em;
+}
+
+.login-form {
+    padding: 40px 30px;
+}
+
+.form-group {
+    margin-bottom: 24px;
+}
+
+.form-group label {
+    display: block;
+    margin-bottom: 8px;
+    font-weight: 600;
+    color: #333;
+    font-size: 0.95em;
+}
+
+.form-input {
+    width: 100%;
+    padding: 12px 16px;
+    border: 2px solid #e0e0e0;
+    border-radius: 8px;
+    font-size: 1em;
+    transition: all 0.3s ease;
+    box-sizing: border-box;
+}
+
+.form-input:focus {
+    outline: none;
+    border-color: #667eea;
+    box-shadow: 0 0 0 3px rgba(102, 126, 234, 0.1);
+}
+
+.form-input::placeholder {
+    color: #aaa;
+}
+
+.error-message {
+    background: #fee;
+    color: #c33;
+    padding: 12px 16px;
+    border-radius: 8px;
+    margin-bottom: 20px;
+    border-left: 4px solid #c33;
+    font-size: 0.9em;
+}
+
+.login-button {
+    width: 100%;
+    padding: 14px;
+    background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
+    color: white;
+    border: none;
+    border-radius: 8px;
+    font-size: 1.05em;
+    font-weight: 600;
+    cursor: pointer;
+    transition: all 0.3s ease;
+    position: relative;
+}
+
+.login-button:hover {
+    transform: translateY(-2px);
+    box-shadow: 0 8px 20px rgba(102, 126, 234, 0.4);
+}
+
+.login-button:active {
+    transform: translateY(0);
+}
+
+.login-button:disabled {
+    opacity: 0.6;
+    cursor: not-allowed;
+    transform: none;
+}
+
+.button-spinner {
+    display: inline-block;
+    animation: spin 1s linear infinite;
+}
+
+@keyframes spin {
+    0% { transform: rotate(0deg); }
+    100% { transform: rotate(360deg); }
+}
+
+.login-footer {
+    background: #f8f9fa;
+    padding: 20px 30px;
+    border-top: 1px solid #e0e0e0;
+}
+
+.demo-credentials {
+    margin: 0;
+    text-align: center;
+    font-size: 0.9em;
+    color: #666;
+    line-height: 1.6;
+}
+
+.demo-credentials code {
+    background: #e8eaf6;
+    padding: 2px 8px;
+    border-radius: 4px;
+    color: #5e35b1;
+    font-family: 'Monaco', 'Courier New', monospace;
+    font-size: 0.95em;
+}
+
+@media (max-width: 480px) {
+    .login-card {
+        border-radius: 0;
+        max-width: 100%;
+    }
+
+    .login-header {
+        padding: 30px 20px;
+    }
+
+    .login-form {
+        padding: 30px 20px;
+    }
+
+    .login-footer {
+        padding: 15px 20px;
+    }
+}

--- a/examples/rpcdescribe/src/petstore/static/css/logout.css
+++ b/examples/rpcdescribe/src/petstore/static/css/logout.css
@@ -1,0 +1,154 @@
+body {
+    margin: 0;
+    padding: 0;
+    font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
+    background-color: #f0f2f5;
+    color: #333;
+}
+
+.logout-container {
+    min-height: 100vh;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
+}
+
+.logout-card {
+    background: white;
+    border-radius: 16px;
+    box-shadow: 0 20px 60px rgba(0, 0, 0, 0.3);
+    width: 100%;
+    max-width: 420px;
+    overflow: hidden;
+}
+
+.logout-header {
+    background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
+    color: white;
+    padding: 40px 30px;
+    text-align: center;
+}
+
+.logout-header h1 {
+    margin: 0 0 10px 0;
+    font-size: 2em;
+    font-weight: 700;
+}
+
+.logout-header p {
+    margin: 0;
+    opacity: 0.9;
+    font-size: 1em;
+}
+
+.logout-content {
+    padding: 40px 30px;
+    text-align: center;
+}
+
+.logout-icon {
+    margin-bottom: 24px;
+    color: #667eea;
+    display: flex;
+    justify-content: center;
+}
+
+.logout-message {
+    font-size: 1.1em;
+    color: #333;
+    margin-bottom: 32px;
+    line-height: 1.5;
+}
+
+.logout-form {
+    display: flex;
+    flex-direction: column;
+    gap: 12px;
+}
+
+.logout-button {
+    width: 100%;
+    padding: 14px;
+    background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
+    color: white;
+    border: none;
+    border-radius: 8px;
+    font-size: 1.05em;
+    font-weight: 600;
+    cursor: pointer;
+    transition: all 0.3s ease;
+    position: relative;
+}
+
+.logout-button:hover {
+    transform: translateY(-2px);
+    box-shadow: 0 8px 20px rgba(102, 126, 234, 0.4);
+}
+
+.logout-button:active {
+    transform: translateY(0);
+}
+
+.logout-button:disabled {
+    opacity: 0.6;
+    cursor: not-allowed;
+    transform: none;
+}
+
+.button-spinner {
+    display: inline-block;
+    animation: spin 1s linear infinite;
+}
+
+@keyframes spin {
+    0% { transform: rotate(0deg); }
+    100% { transform: rotate(360deg); }
+}
+
+.cancel-button {
+    width: 100%;
+    padding: 14px;
+    background: #f5f5f5;
+    color: #666;
+    border: none;
+    border-radius: 8px;
+    font-size: 1.05em;
+    font-weight: 600;
+    cursor: pointer;
+    transition: all 0.3s ease;
+    text-decoration: none;
+    display: inline-block;
+    box-sizing: border-box;
+}
+
+.cancel-button:hover {
+    background: #e8e8e8;
+    color: #333;
+}
+
+.error-message {
+    background: #fee;
+    color: #c33;
+    padding: 12px 16px;
+    border-radius: 8px;
+    margin-top: 20px;
+    border-left: 4px solid #c33;
+    font-size: 0.9em;
+    text-align: left;
+}
+
+@media (max-width: 480px) {
+    .logout-card {
+        border-radius: 0;
+        max-width: 100%;
+    }
+
+    .logout-header {
+        padding: 30px 20px;
+    }
+
+    .logout-content {
+        padding: 30px 20px;
+    }
+}

--- a/examples/rpcdescribe/src/petstore/static/css/petstore.css
+++ b/examples/rpcdescribe/src/petstore/static/css/petstore.css
@@ -24,13 +24,15 @@
 }
 
 body {
+  margin: 0;
+  padding: 0;
   font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, sans-serif;
-  color: var(--text-primary);
   line-height: 1.6;
-  background-color: var(--bg-light);
+  background-color: #f0f2f5;
+  color: #333;
 }
 
-.container {
+.partials-view {
   max-width: 1200px;
   margin: 0 auto;
   padding: 0 20px;
@@ -241,8 +243,6 @@ section {
 }
 
 .method-header {
-  display: flex;
-  align-items: center;
   gap: 0.75rem;
   margin-bottom: 0.75rem;
 }
@@ -279,7 +279,6 @@ section {
 .method-description {
   color: var(--text-secondary);
   margin-bottom: 1rem;
-  font-size: 0.875rem;
 }
 
 .method-params {

--- a/examples/rpcdescribe/src/petstore/static/js/login.js
+++ b/examples/rpcdescribe/src/petstore/static/js/login.js
@@ -1,0 +1,57 @@
+document.getElementById('loginForm').addEventListener('submit', async (e) => {
+    e.preventDefault();
+
+    const username = document.getElementById('username').value;
+    const password = document.getElementById('password').value;
+    const errorMessage = document.getElementById('errorMessage');
+    const loginButton = document.getElementById('loginButton');
+    const buttonText = loginButton.querySelector('.button-text');
+    const buttonSpinner = loginButton.querySelector('.button-spinner');
+
+    // Clear previous errors
+    errorMessage.style.display = 'none';
+    errorMessage.textContent = '';
+
+    // Disable button and show spinner
+    loginButton.disabled = true;
+    buttonText.style.display = 'none';
+    buttonSpinner.style.display = 'inline-block';
+
+    try {
+        const response = await fetch('/login', {
+            method: 'POST',
+            headers: {
+                'Content-Type': 'application/json',
+            },
+            body: JSON.stringify({
+                username: username,
+                password: password
+            })
+        });
+
+        const data = await response.json();
+
+        if (response.ok && data.access_token) {
+            // Store the JWT token
+            localStorage.setItem('jwt', data.access_token);
+
+            // Redirect to dashboard or home
+            window.location.href = '/api/browse';
+        } else {
+            localStorage.removeItem('jwt');
+
+            // Show error message
+            errorMessage.textContent = data.msg || 'Invalid username or password';
+            errorMessage.style.display = 'block';
+        }
+    } catch (error) {
+        errorMessage.textContent = 'An error occurred. Please try again.';
+        errorMessage.style.display = 'block';
+        console.error('Login error:', error);
+    } finally {
+        // Re-enable button and hide spinner
+        loginButton.disabled = false;
+        buttonText.style.display = 'inline';
+        buttonSpinner.style.display = 'none';
+    }
+});

--- a/examples/rpcdescribe/src/petstore/static/js/logout.js
+++ b/examples/rpcdescribe/src/petstore/static/js/logout.js
@@ -1,0 +1,54 @@
+document.addEventListener('DOMContentLoaded', () => {
+    const logoutForm = document.getElementById('logoutForm');
+    const errorMessage = document.getElementById('errorMessage');
+    const logoutButton = document.getElementById('logoutButton');
+    const buttonText = logoutButton.querySelector('.button-text');
+    const buttonSpinner = logoutButton.querySelector('.button-spinner');
+
+    logoutForm.addEventListener('submit', async (e) => {
+        e.preventDefault();
+
+        // Clear previous errors
+        errorMessage.style.display = 'none';
+        errorMessage.textContent = '';
+
+        // Disable button and show spinner
+        logoutButton.disabled = true;
+        buttonText.style.display = 'none';
+        buttonSpinner.style.display = 'inline-block';
+
+        try {
+            // Get the access token
+            const accessToken = localStorage.getItem('jwt');
+
+            const response = await fetch('/logout', {
+                method: 'POST',
+                headers: {
+                    'Content-Type': 'application/json',
+                    'Authorization': `Bearer ${accessToken}`
+                }
+            });
+
+            if (response.ok) {
+                // Clear the JWT token
+                localStorage.removeItem('jwt');
+
+                // Redirect to login page
+                window.location.href = '/api/browse/login';
+            } else {
+                const data = await response.json();
+                errorMessage.textContent = data.msg || 'Failed to logout. Please try again.';
+                errorMessage.style.display = 'block';
+            }
+        } catch (error) {
+            errorMessage.textContent = 'An error occurred. Please try again.';
+            errorMessage.style.display = 'block';
+            console.error('Logout error:', error);
+        } finally {
+            // Re-enable button and hide spinner
+            logoutButton.disabled = false;
+            buttonText.style.display = 'inline';
+            buttonSpinner.style.display = 'none';
+        }
+    });
+});

--- a/examples/rpcdescribe/src/petstore/templates/browse/login.html
+++ b/examples/rpcdescribe/src/petstore/templates/browse/login.html
@@ -1,0 +1,64 @@
+{% extends "layout.html" %}
+
+{% block title %}Login - {{ browse_title }}{% endblock %}
+
+{% block style %}
+<link href="{{ url_for('static', filename='css/login.css') }}" rel="stylesheet"/>
+{% endblock %}
+
+{% block script %}
+<script src="{{ url_for('static', filename='js/login.js') }}"></script>
+{% endblock %}
+
+{% block page %}
+<div class="login-container">
+    <div class="login-card">
+        <div class="login-header">
+            <h1>🔐 Login</h1>
+            <p>Sign in to access the {{ browse_title }}</p>
+        </div>
+
+        <form id="loginForm" class="login-form" action="/login" method="post">
+            <div class="form-group">
+                <label for="username">Username</label>
+                <input
+                    type="text"
+                    id="username"
+                    name="username"
+                    class="form-input"
+                    placeholder="Enter your username"
+                    required
+                    autocomplete="username"
+                >
+            </div>
+
+            <div class="form-group">
+                <label for="password">Password</label>
+                <input
+                    type="password"
+                    id="password"
+                    name="password"
+                    class="form-input"
+                    placeholder="Enter your password"
+                    required
+                    autocomplete="current-password"
+                >
+            </div>
+
+            <div id="errorMessage" class="error-message" style="display: none;"></div>
+
+            <button type="submit" class="login-button" id="loginButton">
+                <span class="button-text">Sign In</span>
+                <span class="button-spinner" style="display: none;">⏳</span>
+            </button>
+        </form>
+
+        <div class="login-footer">
+            <p class="demo-credentials">
+                <strong>Demo credentials:</strong><br>
+                Username: <code>test</code> | Password: <code>test</code>
+            </p>
+        </div>
+    </div>
+</div>
+{% endblock %}

--- a/examples/rpcdescribe/src/petstore/templates/browse/logout.html
+++ b/examples/rpcdescribe/src/petstore/templates/browse/logout.html
@@ -1,0 +1,44 @@
+{% extends "layout.html" %}
+
+{% block title %}Logout - {{ browse_title }}{% endblock %}
+
+{% block style %}
+<link href="{{ url_for('static', filename='css/logout.css') }}" rel="stylesheet"/>
+{% endblock %}
+
+{% block script %}
+<script src="{{ url_for('static', filename='js/logout.js') }}"></script>
+{% endblock %}
+
+{% block page %}
+<div class="logout-container">
+    <div class="logout-card">
+        <div class="logout-header">
+            <h1>👋 Logout</h1>
+            <p>Sign out from {{ browse_title }}</p>
+        </div>
+
+        <div class="logout-content">
+            <div class="logout-icon">
+                <svg width="80" height="80" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+                    <path d="M17 7L15.59 8.41L18.17 11H8V13H18.17L15.59 15.58L17 17L22 12L17 7Z" fill="currentColor"/>
+                    <path d="M4 5H12V3H4C2.9 3 2 3.9 2 5V19C2 20.1 2.9 21 4 21H12V19H4V5Z" fill="currentColor"/>
+                </svg>
+            </div>
+
+            <p class="logout-message">Are you sure you want to sign out?</p>
+
+            <form id="logoutForm" class="logout-form" action="/logout" method="post">
+                <button type="submit" class="logout-button" id="logoutButton">
+                    <span class="button-text">Sign Out</span>
+                    <span class="button-spinner" style="display: none;">⏳</span>
+                </button>
+
+                <a href="/api/browse" class="cancel-button">Cancel</a>
+            </form>
+
+            <div id="errorMessage" class="error-message" style="display: none;"></div>
+        </div>
+    </div>
+</div>
+{% endblock %}

--- a/examples/rpcdescribe/src/petstore/templates/browse/partials/dashboard.html
+++ b/examples/rpcdescribe/src/petstore/templates/browse/partials/dashboard.html
@@ -9,6 +9,7 @@
         </div>
         <nav class="main-nav">
           <a href="#overview" class="nav-link active">Overview</a>
+          <a href="/api/browse/logout" class="nav-link">Logout</a>
         </nav>
       </div>
     </div>

--- a/examples/rpcdescribe/uv.lock
+++ b/examples/rpcdescribe/uv.lock
@@ -367,6 +367,20 @@ typing = [
 ]
 
 [[package]]
+name = "flask-jwt-extended"
+version = "4.7.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "flask" },
+    { name = "pyjwt" },
+    { name = "werkzeug" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/51/16/96b101f18cba17ecce3225ab07bc4c8f23e6befd8552dbbed87482e7c7fb/flask_jwt_extended-4.7.1.tar.gz", hash = "sha256:8085d6757505b6f3291a2638c84d207e8f0ad0de662d1f46aa2f77e658a0c976", size = 34411, upload-time = "2024-11-20T23:44:41.044Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/67/34/9a91da47b1565811ab4aa5fb134632c8d1757960bfa7d457f486947c4d75/Flask_JWT_Extended-4.7.1-py2.py3-none-any.whl", hash = "sha256:52f35bf0985354d7fb7b876e2eb0e0b141aaff865a22ff6cc33d9a18aa987978", size = 22588, upload-time = "2024-11-20T23:44:39.435Z" },
+]
+
+[[package]]
 name = "iniconfig"
 version = "2.3.0"
 source = { registry = "https://pypi.org/simple" }
@@ -660,6 +674,15 @@ wheels = [
 ]
 
 [[package]]
+name = "pyjwt"
+version = "2.10.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e7/46/bd74733ff231675599650d3e47f361794b22ef3e3770998dda30d3b63726/pyjwt-2.10.1.tar.gz", hash = "sha256:3cc5772eb20009233caf06e9d8a0577824723b44e6648ee0a2aedb6cf9381953", size = 87785, upload-time = "2024-11-28T03:43:29.933Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/61/ad/689f02752eeec26aed679477e80e632ef1b682313be70793d798c1d5fc8f/PyJWT-2.10.1-py3-none-any.whl", hash = "sha256:dcdd193e30abefd5debf142f9adfcdd2b58004e644f25406ffaebd50bd98dacb", size = 22997, upload-time = "2024-11-28T03:43:27.893Z" },
+]
+
+[[package]]
 name = "pyproject-api"
 version = "1.10.0"
 source = { registry = "https://pypi.org/simple" }
@@ -749,6 +772,7 @@ version = "1.0.0"
 source = { editable = "." }
 dependencies = [
     { name = "flask-jsonrpc" },
+    { name = "flask-jwt-extended" },
 ]
 
 [package.optional-dependencies]
@@ -773,6 +797,7 @@ tests = [
 requires-dist = [
     { name = "flask", extras = ["async"], marker = "extra == 'async'", specifier = ">=3.0.0,<4.0" },
     { name = "flask-jsonrpc", editable = "../../" },
+    { name = "flask-jwt-extended", specifier = ">=4.7.1" },
 ]
 provides-extras = ["async"]
 

--- a/src/flask_jsonrpc/app.py
+++ b/src/flask_jsonrpc/app.py
@@ -81,7 +81,8 @@ class JSONRPC(JSONRPCDecoratorMixin):
 
     def init_app(self: Self, app: Flask) -> None:
         for setting, value in app.config.items():
-            setattr(settings, setting.upper(), value)
+            if settings.IS_ENV_KEY(setting):
+                setattr(settings, settings.ENV_TO_CONFIG(setting), value)
 
         http_host = app.config.get('SERVER_NAME')
         app_root = app.config['APPLICATION_ROOT']
@@ -112,6 +113,8 @@ class JSONRPC(JSONRPCDecoratorMixin):
 
         if self.enable_web_browsable_api is True or (self.enable_web_browsable_api is None and app.config['DEBUG']):
             self.init_browse_app(app)
+
+        self.app = app
 
     def register(
         self: Self,

--- a/src/flask_jsonrpc/conf/global_settings.py
+++ b/src/flask_jsonrpc/conf/global_settings.py
@@ -26,9 +26,29 @@
 # POSSIBILITY OF SUCH DAMAGE.
 from __future__ import annotations
 
-DEBUG = False
+import typing as t
 
+if t.TYPE_CHECKING:
+    from flask import typing as ft
+    from flask.wrappers import Request, Response
+
+DEBUG = False
 TESTING = False
+
+_FLASK_JSONRPC_ENV_PREFIX = 'FLASK_JSONRPC_'
+
+
+def IS_ENV_KEY(key: str) -> bool:
+    return key.upper().startswith(_FLASK_JSONRPC_ENV_PREFIX)
+
+
+def ENV_TO_CONFIG(key: str) -> str:
+    return key.replace(_FLASK_JSONRPC_ENV_PREFIX, '').upper()
+
+
+def CONFIG_TO_ENV(key: str) -> str:
+    return f'{_FLASK_JSONRPC_ENV_PREFIX}{key.upper()}'
+
 
 DEFAULT_JSONRPC_METHOD_VALIDATE = True
 DEFAULT_JSONRPC_METHOD_NOTIFICATION = True
@@ -39,6 +59,16 @@ BROWSE_SUBTITLE = 'Web browsable API'
 BROWSE_DESCRIPTION = 'An interactive web browsable API for Flask JSON-RPC services'
 BROWSE_FORK_ME_BUTTON_ENABLED = True
 BROWSE_DASHBOARD_MENU_NAME = 'Dashboard'
-BROWSE_DASHBOARD_TEMPLATE = 'browse/partials/dashboard.html'
+BROWSE_DASHBOARD_PARTIAL_TEMPLATE = 'browse/partials/dashboard.html'
+BROWSE_LOGIN_TEMPLATE: str | None = None
+BROWSE_LOGOUT_TEMPLATE: str | None = None
 BROWSE_MEDIA_CSS: dict[str, list[str]] = {}  # {media: [css_file, ...]}
 BROWSE_MEDIA_JS: list[str] = []
+BROWSE_MIDDLEWARE: list[
+    tuple[
+        str,
+        t.Callable[
+            [Request], t.Generator[ft.ResponseReturnValue | bool | None, Response, ft.ResponseReturnValue | None]
+        ],
+    ]
+] = []

--- a/src/flask_jsonrpc/contrib/browse/__init__.py
+++ b/src/flask_jsonrpc/contrib/browse/__init__.py
@@ -27,12 +27,14 @@
 from __future__ import annotations
 
 import typing as t
+from functools import wraps
+import contextlib
 from collections import ChainMap
 
 # Added in version 3.11.
 from typing_extensions import Self
 
-from flask import Blueprint, request, render_template
+from flask import Flask, Blueprint, g, typing as ft, request, render_template
 
 from jinja2 import BaseLoader, TemplateNotFound
 
@@ -41,12 +43,99 @@ from flask_jsonrpc.helpers import Node, urn
 from flask_jsonrpc.encoders import jsonify, serializable
 
 if t.TYPE_CHECKING:
-    from flask import Flask, typing as ft
+    from flask.wrappers import Request, Response
 
     from jinja2.environment import Environment
 
     from flask_jsonrpc.site import JSONRPCSite
     from flask_jsonrpc.typing import Method
+
+
+def register_middleware(
+    name: str,
+) -> t.Callable[
+    [t.Callable[[Request], t.Generator[ft.ResponseReturnValue | bool | None, Response, ft.ResponseReturnValue | None]]],
+    t.Callable[[Request], t.Generator[ft.ResponseReturnValue | bool | None, Response, ft.ResponseReturnValue | None]],
+]:
+    def decorator(
+        fn: t.Callable[
+            [Request], t.Generator[ft.ResponseReturnValue | bool | None, Response, ft.ResponseReturnValue | None]
+        ],
+    ) -> t.Callable[
+        [Request], t.Generator[ft.ResponseReturnValue | bool | None, Response, ft.ResponseReturnValue | None]
+    ]:
+        @wraps(fn)
+        def wrapper(
+            request: Request,
+        ) -> t.Generator[ft.ResponseReturnValue | bool | None, Response, ft.ResponseReturnValue | None]:
+            gen = fn(request)
+            if not hasattr(gen, '__next__'):
+                raise TypeError("middleware function must be a generator (must use 'yield')")
+            return gen
+
+        settings.BROWSE_MIDDLEWARE.append((name, wrapper))
+        return wrapper
+
+    return decorator
+
+
+def _before_request_middleware() -> ft.ResponseReturnValue | None:
+    middlewares: list[
+        tuple[
+            str,
+            t.Callable[
+                [Request], t.Generator[ft.ResponseReturnValue | bool | None, Response, ft.ResponseReturnValue | None]
+            ],
+        ]
+    ] = settings.BROWSE_MIDDLEWARE
+    g._jsonrpc_browse_mw = {}
+    for name, middleware in middlewares:
+        gen = middleware(request)
+        rv = next(gen, None)
+        if rv is False:
+            continue
+        if rv is True:
+            g._jsonrpc_browse_mw[name] = gen
+            continue
+        if rv is not None:
+            return rv
+    return None
+
+
+def _after_request_middleware(response: Response) -> ft.ResponseReturnValue:
+    middlewares: list[
+        tuple[
+            str,
+            t.Callable[
+                [Request], t.Generator[ft.ResponseReturnValue | bool | None, Response, ft.ResponseReturnValue | None]
+            ],
+        ]
+    ] = settings.BROWSE_MIDDLEWARE
+    gens = g.pop('_jsonrpc_browse_mw', {})
+    for name, _ in reversed(middlewares):
+        gen = gens.pop(name, None)
+        if gen is None:
+            continue
+        try:
+            gen.send(response)
+            rv = next(gen, None)
+            if rv is False:
+                continue
+            if rv is True:
+                continue
+            if rv is not None:
+                g._jsonrpc_browse_mw = {}
+                return t.cast(ft.ResponseReturnValue, rv)
+        finally:
+            gen.close()
+    return response
+
+
+def _teardown_request_middleware(exception: BaseException | None) -> None:
+    gens = g.pop('_jsonrpc_browse_mw', {})
+    for gen in gens.values():
+        with contextlib.suppress(BaseException):
+            gen.close()
 
 
 def build_package_tree(service_methods: dict[str, Method]) -> dict[str, t.Any]:
@@ -99,6 +188,28 @@ class JSONRPCBrowse:
     def _service_methods_desc(self: Self) -> dict[str, Method]:
         return dict(ChainMap(*[site.describe().methods for site in self.jsonrpc_sites]))
 
+    def _base_template_context(self: Self) -> dict[str, t.Any]:
+        server_urls: dict[str, str] = {}
+        service_describes = [site.describe() for site in self.jsonrpc_sites]
+        for service_describe in service_describes:
+            server_urls.update(dict.fromkeys(service_describe.methods, service_describe.servers[0].url))
+        url_prefix = f'{request.script_root}{request.path.rstrip("/")}'
+        context = {
+            'url_prefix': url_prefix,
+            'server_urls': server_urls,
+            'browse_title': self.get_browse_title(),
+            'browse_title_url': self.get_browse_title_url(),
+            'browse_subtitle': self.get_browse_subtitle(),
+            'browse_description': self.get_browse_description(),
+            'browse_fork_me_button_enabled': self.get_browse_fork_me_button_enabled(),
+            'browse_dashboard_menu_name': self.get_browse_dashboard_menu_name(),
+            'browse_login_template_enabled': self.get_browse_login_template() is not None,
+            'browse_logout_template_enabled': self.get_browse_logout_template() is not None,
+            'browse_media_css': self.get_browse_media_css(),
+            'browse_media_js': self.get_browse_media_js(),
+        }
+        return context
+
     def init_app(self: Self, app: Flask) -> None:
         name = urn('browse', app.name, self.url_prefix)
         browse = Blueprint(name, __name__, template_folder='templates', static_folder='static')
@@ -106,7 +217,12 @@ class JSONRPCBrowse:
             app_jinja_loader=app.jinja_loader,  # type: ignore
             browse_jinja_loader=browse.jinja_loader,  # type: ignore
         )
+        browse.before_request(_before_request_middleware)
+        browse.after_request(_after_request_middleware)
+        browse.teardown_request(_teardown_request_middleware)
         browse.add_url_rule('/', view_func=self.vf_index)
+        browse.add_url_rule('/login', view_func=self.vf_login)
+        browse.add_url_rule('/logout', view_func=self.vf_logout)
         browse.add_url_rule('/packages.json', view_func=self.vf_json_packages)
         browse.add_url_rule('/<method_name>.json', view_func=self.vf_json_method)
         browse.add_url_rule('/partials/menu_tree.html', view_func=self.vf_partials_menu_tree)
@@ -118,6 +234,8 @@ class JSONRPCBrowse:
         app.add_url_rule(
             f'{self.url_prefix}/static/<path:filename>', 'urn:browse.static', view_func=app.send_static_file
         )
+        app.teardown_appcontext(_teardown_request_middleware)
+        self.app = app
 
     def register_jsonrpc_site(self: Self, jsonrpc_site: JSONRPCSite) -> None:
         self.jsonrpc_sites.add(jsonrpc_site)
@@ -146,28 +264,41 @@ class JSONRPCBrowse:
     def get_browse_dashboard_menu_name(self: Self) -> str:
         return t.cast(str, settings.BROWSE_DASHBOARD_MENU_NAME)
 
-    def get_browse_dashboard_template(self: Self) -> str:
-        return t.cast(str, settings.BROWSE_DASHBOARD_TEMPLATE)
+    def get_browse_dashboard_partial_template(self: Self) -> str:
+        return t.cast(str, settings.BROWSE_DASHBOARD_PARTIAL_TEMPLATE)
+
+    def get_browse_login_template(self: Self) -> str | None:
+        if settings.BROWSE_LOGIN_TEMPLATE is None:
+            return None
+        return t.cast(str, settings.BROWSE_LOGIN_TEMPLATE)
+
+    def get_browse_logout_template(self: Self) -> str | None:
+        if settings.BROWSE_LOGOUT_TEMPLATE is None:
+            return None
+        return t.cast(str, settings.BROWSE_LOGOUT_TEMPLATE)
 
     def vf_index(self: Self) -> str:
-        server_urls: dict[str, str] = {}
-        service_describes = [site.describe() for site in self.jsonrpc_sites]
-        for service_describe in service_describes:
-            server_urls.update(dict.fromkeys(service_describe.methods, service_describe.servers[0].url))
-        url_prefix = f'{request.script_root}{request.path.rstrip("/")}'
-        context = {
-            'url_prefix': url_prefix,
-            'server_urls': server_urls,
-            'browse_title': self.get_browse_title(),
-            'browse_title_url': self.get_browse_title_url(),
-            'browse_subtitle': self.get_browse_subtitle(),
-            'browse_description': self.get_browse_description(),
-            'browse_fork_me_button_enabled': self.get_browse_fork_me_button_enabled(),
-            'browse_dashboard_menu_name': self.get_browse_dashboard_menu_name(),
-            'browse_media_css': self.get_browse_media_css(),
-            'browse_media_js': self.get_browse_media_js(),
-        }
-        return render_template('browse/index.html', **context)
+        return render_template('browse/index.html', **self._base_template_context())
+
+    def vf_login(self: Self) -> str | tuple[str, int]:
+        login_template = self.get_browse_login_template()
+        if login_template is None:
+            return (
+                'Login not configured. To configure, set BROWSE_LOGIN_TEMPLATE '
+                'in your settings or override get_browse_login_template().',
+                404,
+            )
+        return render_template(login_template, **self._base_template_context())
+
+    def vf_logout(self: Self) -> str | tuple[str, int]:
+        logout_template = self.get_browse_logout_template()
+        if logout_template is None:
+            return (
+                'Logout not configured. To configure, set BROWSE_LOGOUT_TEMPLATE '
+                'in your settings or override get_browse_logout_template().',
+                404,
+            )
+        return render_template(logout_template, **self._base_template_context())
 
     def vf_json_packages(self: Self) -> ft.ResponseReturnValue:
         service_methods = {
@@ -189,7 +320,7 @@ class JSONRPCBrowse:
         return render_template('browse/partials/menu_tree.html')
 
     def vf_partials_dashboard(self: Self) -> str:
-        return render_template(self.get_browse_dashboard_template())
+        return render_template(self.get_browse_dashboard_partial_template())
 
     def vf_partials_field_describe(self: Self) -> str:
         return render_template('browse/partials/field_describe.html')

--- a/src/flask_jsonrpc/contrib/browse/static/js/apps/browse/app.js
+++ b/src/flask_jsonrpc/contrib/browse/static/js/apps/browse/app.js
@@ -28,16 +28,21 @@
 
 	App.adjust = function() {
         var viewPortHeight = $(window).outerHeight(true),
-            viewPortWidth = $(window).outerWidth(true),
-            viewPortMenu = viewPortHeight - $('#navbar-main').outerHeight(true) - $('#logo-section').outerHeight(true) - $('#box-subscribe').outerHeight(true),
-            viewPortContent = viewPortHeight - $('#navbar-main').outerHeight(true) - $('#viewer-header-container').outerHeight(true),
-            viewPortIframe = viewPortContent - $('#title-and-status-container').outerHeight(true);
+            viewPortMenu = (
+                viewPortHeight - ($('#navbar-main').outerHeight(true) || 0)
+                    - ($('#logo-section').outerHeight(true) || 0)
+                    - ($('#box-subscribe').outerHeight(true) || 0)
+            ),
+            viewPortContent = (
+                viewPortHeight - ($('#navbar-main').outerHeight(true) || 0)
+                    - ($('#viewer-header-container').outerHeight(true) || 0)
+            );
 
         // Menu
-    	$('#scrollable-sections').height(viewPortMenu);
+    	$('#scrollable-sections').height(Math.max(viewPortMenu, viewPortContent));
 
         // Content master
-    	$('#viewer-entries-container').height(viewPortContent);
+    	$('#viewer-entries-container').height(Math.max(viewPortMenu, viewPortContent));
     };
 
 	App.ready = function(E) {

--- a/src/flask_jsonrpc/contrib/browse/static/js/apps/browse/controllers.js
+++ b/src/flask_jsonrpc/contrib/browse/static/js/apps/browse/controllers.js
@@ -13,14 +13,6 @@
         return ('/'+route === $location.path());
     };
 
-    var breadcrumbs = function(name) {
-        if (name.indexOf('.') !== -1) {
-            var names = name.split('.');
-            return [names[0], name];
-        }
-        return [name];
-    };
-
     var getDefaultParamValues = function(module) {
         if (!module.examples) {
             return {};
@@ -87,7 +79,6 @@
         $scope.showToolbarPlayButton = true;
         $scope.showToolbarRerunButton = false;
         $scope.showToolbarNotifyButton = true;
-        $scope.breadcrumbs = breadcrumbs('Dashboard');
         $scope.response = responseExample;
         $scope.responseObject = responseObjectExample;
 
@@ -97,10 +88,6 @@
 
         $scope.$on('App:displayContentLoaded', function(event, display) {
             $scope.showContentLoaded = display;
-        });
-
-        $scope.$on('App:breadcrumb', function(event, breadcrumb) {
-            $scope.breadcrumbs = breadcrumbs(breadcrumb);
         });
 
         $scope.$on('App:displayToolbar', function(event, display) {
@@ -148,7 +135,6 @@
 
         $scope.goToDashboard = function() {
             $scope.$emit('App:displayToolbar', false);
-            $scope.$emit('App:breadcrumb', 'Dashboard');
             $location.path('/');
         };
 
@@ -231,7 +217,6 @@
         $scope.response = undefined;
         $scope.responseObject = undefined;
         $scope.$emit('App:displayToolbar', true);
-        $scope.$emit('App:breadcrumb', module.name);
         $scope.$emit('App:displayToolbarNotifyButton', module.notification);
 
         var RPCCall = function(module) {

--- a/src/flask_jsonrpc/contrib/browse/templates/browse/index.html
+++ b/src/flask_jsonrpc/contrib/browse/templates/browse/index.html
@@ -87,14 +87,7 @@
       </div>
 
       <div id="viewer-entries-container" class="row">
-        <div id="title-and-status-container" class="row title-and-status-container">
-          <div class="title-and-status-holder">
-            <span id="breadcrumb" class="breadcrumb-title">{% raw %}<span ng-repeat="breadcrumb in breadcrumbs">{{breadcrumb}}<span ng-if="!$last"> &#x00bb; </span></span>{% endraw %}</span>
-          </div>
-          <div class="breadcrumb-title-clear"></div>
-        </div>
-
-        <div ng-view></div>
+        <div class="partials-view" ng-view></div>
       </div>
     </div> <!-- content -->
 

--- a/src/flask_jsonrpc/contrib/browse/templates/browse/partials/response_object.html
+++ b/src/flask_jsonrpc/contrib/browse/templates/browse/partials/response_object.html
@@ -60,11 +60,11 @@
     </div>
 
     <div class="method-info">
-      <div ng-if="module.summary" class="method-summary">
+      <div ng-show="module.summary" class="method-summary">
         <h3 ng-bind-html="module.summary|markdown"></h3>
       </div>
 
-      <div ng-if="module.description" class="method-description">
+      <div ng-show="module.description" class="method-description">
         <div ng-bind-html="module.description|markdown"></div>
       </div>
     </div>

--- a/src/flask_jsonrpc/contrib/browse/templates/layout.html
+++ b/src/flask_jsonrpc/contrib/browse/templates/layout.html
@@ -45,7 +45,7 @@
 </head>
 
 <body id="{% block bodyid %}{% endblock %}">
-
+  {% block page %}
   <div class="wrapper" ng-controller="ApplicationCtrl">
 
   {% block navbar %}
@@ -56,13 +56,12 @@
   </nav>
   {% endblock %}
 
-  <!-- Content -->
   <div id="content" ng-hide="showFakeIntro">
   {% block content %}{% endblock %}
   </div>
-  <!-- END Content -->
 
-  </div><!-- ./wrapper -->
+  </div>
+  {% endblock %}
 
   {% block footer %}{% endblock %}
 

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -68,12 +68,8 @@ def page_session(page: Page) -> t.Generator[t.Callable[..., Page], None, None]:
 
 @pytest.fixture(autouse=True, scope='function')
 def jsonrpc_page_info(page_session: t.Callable[..., Page]) -> t.Generator[t.Callable[..., Page], None, None]:
-    def page_info(
-        jsonrpc_method: str, breadcrumb: str, method_title: str, method_signature: str, method_description: str
-    ) -> Page:
+    def page_info(jsonrpc_method: str, method_title: str, method_signature: str, method_description: str) -> Page:
         page = page_session(jsonrpc_method)
-        breadcrumb_element = page.locator('#breadcrumb')
-        expect(breadcrumb_element).to_contain_text(breadcrumb)
 
         method_title_element = page.locator('.method-title')
         expect(method_title_element).to_contain_text(method_title)

--- a/tests/integration/test_browse.py
+++ b/tests/integration/test_browse.py
@@ -37,9 +37,6 @@ def test_index(page: Page) -> None:
     logo_link = page.locator('#logo-link')
     expect(logo_link).to_have_text('Web browsable API')
 
-    breadcrumb_element = page.locator('#breadcrumb')
-    expect(breadcrumb_element).to_contain_text('Dashboard')
-
     method_signature_title_element = page.locator('.method-title')
     expect(method_signature_title_element).to_contain_text('Api.welcome')
 

--- a/tests/integration/test_browse_app.py
+++ b/tests/integration/test_browse_app.py
@@ -31,17 +31,13 @@ from playwright.sync_api import Page
 
 
 @pytest.mark.parametrize(
-    'breadcrumb,method_title,method_signature,method_description',
-    [('app » app.echo', 'app.echo', 'app.echo(string: String, _some: Object) -> String', '')],
+    'method_title,method_signature,method_description',
+    [('app.echo', 'app.echo(string: String, _some: Object) -> String', '')],
 )
 def test_app_echo_display(
-    jsonrpc_page_info: t.Callable[..., Page],
-    breadcrumb: str,
-    method_title: str,
-    method_signature: str,
-    method_description: str,
+    jsonrpc_page_info: t.Callable[..., Page], method_title: str, method_signature: str, method_description: str
 ) -> None:
-    jsonrpc_page_info('app.echo', breadcrumb, method_title, method_signature, method_description)
+    jsonrpc_page_info('app.echo', method_title, method_signature, method_description)
 
 
 @pytest.mark.parametrize(
@@ -97,17 +93,12 @@ def test_app_echo_form(
 
 
 @pytest.mark.parametrize(
-    'breadcrumb,method_title,method_signature,method_description',
-    [('app » app.notify', 'app.notify', 'app.notify(_string: String) -> Null', '')],
+    'method_title,method_signature,method_description', [('app.notify', 'app.notify(_string: String) -> Null', '')]
 )
 def test_app_notify_display(
-    jsonrpc_page_info: t.Callable[..., Page],
-    breadcrumb: str,
-    method_title: str,
-    method_signature: str,
-    method_description: str,
+    jsonrpc_page_info: t.Callable[..., Page], method_title: str, method_signature: str, method_description: str
 ) -> None:
-    jsonrpc_page_info('app.notify', breadcrumb, method_title, method_signature, method_description)
+    jsonrpc_page_info('app.notify', method_title, method_signature, method_description)
 
 
 @pytest.mark.parametrize(
@@ -137,17 +128,12 @@ def test_app_notify_form(
 
 
 @pytest.mark.parametrize(
-    'breadcrumb,method_title,method_signature,method_description',
-    [('app » app.fails', 'app.fails', 'app.fails(n: Number) -> Number', '')],
+    'method_title,method_signature,method_description', [('app.fails', 'app.fails(n: Number) -> Number', '')]
 )
 def test_app_fails_display(
-    jsonrpc_page_info: t.Callable[..., Page],
-    breadcrumb: str,
-    method_title: str,
-    method_signature: str,
-    method_description: str,
+    jsonrpc_page_info: t.Callable[..., Page], method_title: str, method_signature: str, method_description: str
 ) -> None:
-    jsonrpc_page_info('app.fails', breadcrumb, method_title, method_signature, method_description)
+    jsonrpc_page_info('app.fails', method_title, method_signature, method_description)
 
 
 @pytest.mark.parametrize(
@@ -207,17 +193,13 @@ def test_app_fails_form(
 
 
 @pytest.mark.parametrize(
-    'breadcrumb,method_title,method_signature,method_description',
-    [('app » app.decorators', 'app.decorators', 'app.decorators(string: String) -> String', '')],
+    'method_title,method_signature,method_description',
+    [('app.decorators', 'app.decorators(string: String) -> String', '')],
 )
 def test_app_decorators_display(
-    jsonrpc_page_info: t.Callable[..., Page],
-    breadcrumb: str,
-    method_title: str,
-    method_signature: str,
-    method_description: str,
+    jsonrpc_page_info: t.Callable[..., Page], method_title: str, method_signature: str, method_description: str
 ) -> None:
-    jsonrpc_page_info('app.decorators', breadcrumb, method_title, method_signature, method_description)
+    jsonrpc_page_info('app.decorators', method_title, method_signature, method_description)
 
 
 @pytest.mark.parametrize(
@@ -255,17 +237,13 @@ def test_app_decorators_form(
 
 
 @pytest.mark.parametrize(
-    'breadcrumb,method_title,method_signature,method_description',
-    [('app » app.wrappedDecorators', 'app.wrappedDecorators', 'app.wrappedDecorators(string: String) -> String', '')],
+    'method_title,method_signature,method_description',
+    [('app.wrappedDecorators', 'app.wrappedDecorators(string: String) -> String', '')],
 )
 def test_app_wrapped_decorators_display(
-    jsonrpc_page_info: t.Callable[..., Page],
-    breadcrumb: str,
-    method_title: str,
-    method_signature: str,
-    method_description: str,
+    jsonrpc_page_info: t.Callable[..., Page], method_title: str, method_signature: str, method_description: str
 ) -> None:
-    jsonrpc_page_info('app.wrappedDecorators', breadcrumb, method_title, method_signature, method_description)
+    jsonrpc_page_info('app.wrappedDecorators', method_title, method_signature, method_description)
 
 
 @pytest.mark.parametrize(
@@ -303,24 +281,13 @@ def test_app_wrapped_decorators_form(
 
 
 @pytest.mark.parametrize(
-    'breadcrumb,method_title,method_signature,method_description',
-    [
-        (
-            'app » app.failsWithCustomException',
-            'app.failsWithCustomException',
-            'app.failsWithCustomException(_string: String) -> Null',
-            '',
-        )
-    ],
+    'method_title,method_signature,method_description',
+    [('app.failsWithCustomException', 'app.failsWithCustomException(_string: String) -> Null', '')],
 )
 def test_app_fails_with_custom_exception_display(
-    jsonrpc_page_info: t.Callable[..., Page],
-    breadcrumb: str,
-    method_title: str,
-    method_signature: str,
-    method_description: str,
+    jsonrpc_page_info: t.Callable[..., Page], method_title: str, method_signature: str, method_description: str
 ) -> None:
-    jsonrpc_page_info('app.failsWithCustomException', breadcrumb, method_title, method_signature, method_description)
+    jsonrpc_page_info('app.failsWithCustomException', method_title, method_signature, method_description)
 
 
 @pytest.mark.parametrize(
@@ -377,10 +344,9 @@ def test_app_fails_with_custom_exception_form(
 
 
 @pytest.mark.parametrize(
-    'breadcrumb,method_title,method_signature,method_description',
+    'method_title,method_signature,method_description',
     [
         (
-            'app » app.failsWithCustomExceptionNotRegistered',
             'app.failsWithCustomExceptionNotRegistered',
             'app.failsWithCustomExceptionNotRegistered(_string: String) -> Null',
             '',
@@ -388,15 +354,9 @@ def test_app_fails_with_custom_exception_form(
     ],
 )
 def test_app_fails_with_custom_exception_not_registered_display(
-    jsonrpc_page_info: t.Callable[..., Page],
-    breadcrumb: str,
-    method_title: str,
-    method_signature: str,
-    method_description: str,
+    jsonrpc_page_info: t.Callable[..., Page], method_title: str, method_signature: str, method_description: str
 ) -> None:
-    jsonrpc_page_info(
-        'app.failsWithCustomExceptionNotRegistered', breadcrumb, method_title, method_signature, method_description
-    )
+    jsonrpc_page_info('app.failsWithCustomExceptionNotRegistered', method_title, method_signature, method_description)
 
 
 @pytest.mark.parametrize(

--- a/tests/integration/test_browse_class_apps.py
+++ b/tests/integration/test_browse_class_apps.py
@@ -31,17 +31,13 @@ from playwright.sync_api import Page
 
 
 @pytest.mark.parametrize(
-    'breadcrumb,method_title,method_signature,method_description',
-    [('class_apps » class_apps.index', 'class_apps.index', 'class_apps.index(name: String) -> String', '')],
+    'method_title,method_signature,method_description',
+    [('class_apps.index', 'class_apps.index(name: String) -> String', '')],
 )
 def test_class_apps_index_display(
-    jsonrpc_page_info: t.Callable[..., Page],
-    breadcrumb: str,
-    method_title: str,
-    method_signature: str,
-    method_description: str,
+    jsonrpc_page_info: t.Callable[..., Page], method_title: str, method_signature: str, method_description: str
 ) -> None:
-    jsonrpc_page_info('class_apps.index', breadcrumb, method_title, method_signature, method_description)
+    jsonrpc_page_info('class_apps.index', method_title, method_signature, method_description)
 
 
 @pytest.mark.parametrize(
@@ -79,17 +75,13 @@ def test_class_apps_index_form(
 
 
 @pytest.mark.parametrize(
-    'breadcrumb,method_title,method_signature,method_description',
-    [('class_apps » class_apps.greeting', 'class_apps.greeting', 'class_apps.greeting(name: String) -> String', '')],
+    'method_title,method_signature,method_description',
+    [('class_apps.greeting', 'class_apps.greeting(name: String) -> String', '')],
 )
 def test_class_apps_greeting_display(
-    jsonrpc_page_info: t.Callable[..., Page],
-    breadcrumb: str,
-    method_title: str,
-    method_signature: str,
-    method_description: str,
+    jsonrpc_page_info: t.Callable[..., Page], method_title: str, method_signature: str, method_description: str
 ) -> None:
-    jsonrpc_page_info('class_apps.greeting', breadcrumb, method_title, method_signature, method_description)
+    jsonrpc_page_info('class_apps.greeting', method_title, method_signature, method_description)
 
 
 @pytest.mark.parametrize(
@@ -127,17 +119,13 @@ def test_class_apps_greeting_form(
 
 
 @pytest.mark.parametrize(
-    'breadcrumb,method_title,method_signature,method_description',
-    [('class_apps » class_apps.hello', 'class_apps.hello', 'class_apps.hello(name: String) -> String', '')],
+    'method_title,method_signature,method_description',
+    [('class_apps.hello', 'class_apps.hello(name: String) -> String', '')],
 )
 def test_class_apps_hello_display(
-    jsonrpc_page_info: t.Callable[..., Page],
-    breadcrumb: str,
-    method_title: str,
-    method_signature: str,
-    method_description: str,
+    jsonrpc_page_info: t.Callable[..., Page], method_title: str, method_signature: str, method_description: str
 ) -> None:
-    jsonrpc_page_info('class_apps.hello', breadcrumb, method_title, method_signature, method_description)
+    jsonrpc_page_info('class_apps.hello', method_title, method_signature, method_description)
 
 
 @pytest.mark.parametrize(
@@ -175,24 +163,13 @@ def test_class_apps_hello_form(
 
 
 @pytest.mark.parametrize(
-    'breadcrumb,method_title,method_signature,method_description',
-    [
-        (
-            'class_apps » class_apps.echo',
-            'class_apps.echo',
-            'class_apps.echo(string: String, _some: Object) -> String',
-            '',
-        )
-    ],
+    'method_title,method_signature,method_description',
+    [('class_apps.echo', 'class_apps.echo(string: String, _some: Object) -> String', '')],
 )
 def test_class_apps_echo_display(
-    jsonrpc_page_info: t.Callable[..., Page],
-    breadcrumb: str,
-    method_title: str,
-    method_signature: str,
-    method_description: str,
+    jsonrpc_page_info: t.Callable[..., Page], method_title: str, method_signature: str, method_description: str
 ) -> None:
-    jsonrpc_page_info('class_apps.echo', breadcrumb, method_title, method_signature, method_description)
+    jsonrpc_page_info('class_apps.echo', method_title, method_signature, method_description)
 
 
 @pytest.mark.parametrize(
@@ -238,17 +215,13 @@ def test_class_apps_echo_form(
 
 
 @pytest.mark.parametrize(
-    'breadcrumb,method_title,method_signature,method_description',
-    [('class_apps » class_apps.notify', 'class_apps.notify', 'class_apps.notify(_string: String) -> Null', '')],
+    'method_title,method_signature,method_description',
+    [('class_apps.notify', 'class_apps.notify(_string: String) -> Null', '')],
 )
 def test_class_apps_notify_display(
-    jsonrpc_page_info: t.Callable[..., Page],
-    breadcrumb: str,
-    method_title: str,
-    method_signature: str,
-    method_description: str,
+    jsonrpc_page_info: t.Callable[..., Page], method_title: str, method_signature: str, method_description: str
 ) -> None:
-    jsonrpc_page_info('class_apps.notify', breadcrumb, method_title, method_signature, method_description)
+    jsonrpc_page_info('class_apps.notify', method_title, method_signature, method_description)
 
 
 @pytest.mark.parametrize(
@@ -282,24 +255,13 @@ def test_class_apps_notify_form(
 
 
 @pytest.mark.parametrize(
-    'breadcrumb,method_title,method_signature,method_description',
-    [
-        (
-            'class_apps » class_apps.not_allow_notify',
-            'class_apps.not_allow_notify',
-            'class_apps.not_allow_notify(_string: String) -> String',
-            '',
-        )
-    ],
+    'method_title,method_signature,method_description',
+    [('class_apps.not_allow_notify', 'class_apps.not_allow_notify(_string: String) -> String', '')],
 )
 def test_class_apps_not_allow_notify_display(
-    jsonrpc_page_info: t.Callable[..., Page],
-    breadcrumb: str,
-    method_title: str,
-    method_signature: str,
-    method_description: str,
+    jsonrpc_page_info: t.Callable[..., Page], method_title: str, method_signature: str, method_description: str
 ) -> None:
-    jsonrpc_page_info('class_apps.not_allow_notify', breadcrumb, method_title, method_signature, method_description)
+    jsonrpc_page_info('class_apps.not_allow_notify', method_title, method_signature, method_description)
 
 
 @pytest.mark.parametrize(
@@ -337,17 +299,13 @@ def test_class_apps_not_allow_notify_form(
 
 
 @pytest.mark.parametrize(
-    'breadcrumb,method_title,method_signature,method_description',
-    [('class_apps » class_apps.fails', 'class_apps.fails', 'class_apps.fails(n: Number) -> Number', '')],
+    'method_title,method_signature,method_description',
+    [('class_apps.fails', 'class_apps.fails(n: Number) -> Number', '')],
 )
 def test_class_apps_fails_display(
-    jsonrpc_page_info: t.Callable[..., Page],
-    breadcrumb: str,
-    method_title: str,
-    method_signature: str,
-    method_description: str,
+    jsonrpc_page_info: t.Callable[..., Page], method_title: str, method_signature: str, method_description: str
 ) -> None:
-    jsonrpc_page_info('class_apps.fails', breadcrumb, method_title, method_signature, method_description)
+    jsonrpc_page_info('class_apps.fails', method_title, method_signature, method_description)
 
 
 @pytest.mark.parametrize(

--- a/tests/integration/test_browse_decorators.py
+++ b/tests/integration/test_browse_decorators.py
@@ -31,24 +31,13 @@ from playwright.sync_api import Page
 
 
 @pytest.mark.parametrize(
-    'breadcrumb,method_title,method_signature,method_description',
-    [
-        (
-            'decorators » decorators.decorator',
-            'decorators.decorator',
-            'decorators.decorator(string: String) -> String',
-            '',
-        )
-    ],
+    'method_title,method_signature,method_description',
+    [('decorators.decorator', 'decorators.decorator(string: String) -> String', '')],
 )
 def test_decorators_decorator_display(
-    jsonrpc_page_info: t.Callable[..., Page],
-    breadcrumb: str,
-    method_title: str,
-    method_signature: str,
-    method_description: str,
+    jsonrpc_page_info: t.Callable[..., Page], method_title: str, method_signature: str, method_description: str
 ) -> None:
-    jsonrpc_page_info('decorators.decorator', breadcrumb, method_title, method_signature, method_description)
+    jsonrpc_page_info('decorators.decorator', method_title, method_signature, method_description)
 
 
 @pytest.mark.parametrize(
@@ -104,24 +93,13 @@ def test_decorators_decorator_form(
 
 
 @pytest.mark.parametrize(
-    'breadcrumb,method_title,method_signature,method_description',
-    [
-        (
-            'decorators » decorators.wrappedDecorator',
-            'decorators.wrappedDecorator',
-            'decorators.wrappedDecorator(string: String) -> String',
-            '',
-        )
-    ],
+    'method_title,method_signature,method_description',
+    [('decorators.wrappedDecorator', 'decorators.wrappedDecorator(string: String) -> String', '')],
 )
 def test_decorators_wrapped_decorator_display(
-    jsonrpc_page_info: t.Callable[..., Page],
-    breadcrumb: str,
-    method_title: str,
-    method_signature: str,
-    method_description: str,
+    jsonrpc_page_info: t.Callable[..., Page], method_title: str, method_signature: str, method_description: str
 ) -> None:
-    jsonrpc_page_info('decorators.wrappedDecorator', breadcrumb, method_title, method_signature, method_description)
+    jsonrpc_page_info('decorators.wrappedDecorator', method_title, method_signature, method_description)
 
 
 @pytest.mark.parametrize(

--- a/tests/integration/test_browse_error_handlers.py
+++ b/tests/integration/test_browse_error_handlers.py
@@ -31,10 +31,9 @@ from playwright.sync_api import Page
 
 
 @pytest.mark.parametrize(
-    'breadcrumb,method_title,method_signature,method_description',
+    'method_title,method_signature,method_description',
     [
         (
-            'error_handlers » error_handlers.failsWithCustomException',
             'error_handlers.failsWithCustomException',
             'error_handlers.failsWithCustomException(_string: String) -> Null',
             '',
@@ -42,15 +41,9 @@ from playwright.sync_api import Page
     ],
 )
 def test_error_handlers_fails_with_custom_exception_display(
-    jsonrpc_page_info: t.Callable[..., Page],
-    breadcrumb: str,
-    method_title: str,
-    method_signature: str,
-    method_description: str,
+    jsonrpc_page_info: t.Callable[..., Page], method_title: str, method_signature: str, method_description: str
 ) -> None:
-    jsonrpc_page_info(
-        'error_handlers.failsWithCustomException', breadcrumb, method_title, method_signature, method_description
-    )
+    jsonrpc_page_info('error_handlers.failsWithCustomException', method_title, method_signature, method_description)
 
 
 @pytest.mark.parametrize(
@@ -124,10 +117,9 @@ def test_error_handlers_fails_with_custom_exception_form(
 
 
 @pytest.mark.parametrize(
-    'breadcrumb,method_title,method_signature,method_description',
+    'method_title,method_signature,method_description',
     [
         (
-            'error_handlers » error_handlers.failsWithCustomExceptionNotRegistered',
             'error_handlers.failsWithCustomExceptionNotRegistered',
             'error_handlers.failsWithCustomExceptionNotRegistered(_string: String) -> Null',
             '',
@@ -135,18 +127,10 @@ def test_error_handlers_fails_with_custom_exception_form(
     ],
 )
 def test_error_handlers_fails_with_custom_exception_not_registered_display(
-    jsonrpc_page_info: t.Callable[..., Page],
-    breadcrumb: str,
-    method_title: str,
-    method_signature: str,
-    method_description: str,
+    jsonrpc_page_info: t.Callable[..., Page], method_title: str, method_signature: str, method_description: str
 ) -> None:
     jsonrpc_page_info(
-        'error_handlers.failsWithCustomExceptionNotRegistered',
-        breadcrumb,
-        method_title,
-        method_signature,
-        method_description,
+        'error_handlers.failsWithCustomExceptionNotRegistered', method_title, method_signature, method_description
     )
 
 

--- a/tests/integration/test_browse_jsonrpc_basic.py
+++ b/tests/integration/test_browse_jsonrpc_basic.py
@@ -31,24 +31,13 @@ from playwright.sync_api import Page
 
 
 @pytest.mark.parametrize(
-    'breadcrumb,method_title,method_signature,method_description',
-    [
-        (
-            'jsonrpc_basic » jsonrpc_basic.echo',
-            'jsonrpc_basic.echo',
-            'jsonrpc_basic.echo(string: String, _some: Object) -> String',
-            '',
-        )
-    ],
+    'method_title,method_signature,method_description',
+    [('jsonrpc_basic.echo', 'jsonrpc_basic.echo(string: String, _some: Object) -> String', '')],
 )
 def test_jsonrpc_basic_echo_display(
-    jsonrpc_page_info: t.Callable[..., Page],
-    breadcrumb: str,
-    method_title: str,
-    method_signature: str,
-    method_description: str,
+    jsonrpc_page_info: t.Callable[..., Page], method_title: str, method_signature: str, method_description: str
 ) -> None:
-    jsonrpc_page_info('jsonrpc_basic.echo', breadcrumb, method_title, method_signature, method_description)
+    jsonrpc_page_info('jsonrpc_basic.echo', method_title, method_signature, method_description)
 
 
 @pytest.mark.parametrize(
@@ -108,24 +97,13 @@ def test_jsonrpc_basic_echo_form(
 
 
 @pytest.mark.parametrize(
-    'breadcrumb,method_title,method_signature,method_description',
-    [
-        (
-            'jsonrpc_basic » jsonrpc_basic.greeting',
-            'jsonrpc_basic.greeting',
-            'jsonrpc_basic.greeting(name: String) -> String',
-            '',
-        )
-    ],
+    'method_title,method_signature,method_description',
+    [('jsonrpc_basic.greeting', 'jsonrpc_basic.greeting(name: String) -> String', '')],
 )
 def test_jsonrpc_basic_greeting_display(
-    jsonrpc_page_info: t.Callable[..., Page],
-    breadcrumb: str,
-    method_title: str,
-    method_signature: str,
-    method_description: str,
+    jsonrpc_page_info: t.Callable[..., Page], method_title: str, method_signature: str, method_description: str
 ) -> None:
-    jsonrpc_page_info('jsonrpc_basic.greeting', breadcrumb, method_title, method_signature, method_description)
+    jsonrpc_page_info('jsonrpc_basic.greeting', method_title, method_signature, method_description)
 
 
 @pytest.mark.parametrize(
@@ -173,24 +151,13 @@ def test_jsonrpc_basic_greeting_form(
 
 
 @pytest.mark.parametrize(
-    'breadcrumb,method_title,method_signature,method_description',
-    [
-        (
-            'jsonrpc_basic » jsonrpc_basic.notify',
-            'jsonrpc_basic.notify',
-            'jsonrpc_basic.notify(_string: String) -> Null',
-            '',
-        )
-    ],
+    'method_title,method_signature,method_description',
+    [('jsonrpc_basic.notify', 'jsonrpc_basic.notify(_string: String) -> Null', '')],
 )
 def test_jsonrpc_basic_notify_display(
-    jsonrpc_page_info: t.Callable[..., Page],
-    breadcrumb: str,
-    method_title: str,
-    method_signature: str,
-    method_description: str,
+    jsonrpc_page_info: t.Callable[..., Page], method_title: str, method_signature: str, method_description: str
 ) -> None:
-    jsonrpc_page_info('jsonrpc_basic.notify', breadcrumb, method_title, method_signature, method_description)
+    jsonrpc_page_info('jsonrpc_basic.notify', method_title, method_signature, method_description)
 
 
 @pytest.mark.parametrize(
@@ -233,24 +200,13 @@ def test_jsonrpc_basic_notify_form(
 
 
 @pytest.mark.parametrize(
-    'breadcrumb,method_title,method_signature,method_description',
-    [
-        (
-            'jsonrpc_basic » jsonrpc_basic.not_allow_notify',
-            'jsonrpc_basic.not_allow_notify',
-            'jsonrpc_basic.not_allow_notify(_string: String) -> String',
-            '',
-        )
-    ],
+    'method_title,method_signature,method_description',
+    [('jsonrpc_basic.not_allow_notify', 'jsonrpc_basic.not_allow_notify(_string: String) -> String', '')],
 )
 def test_jsonrpc_basic_not_allow_notify_display(
-    jsonrpc_page_info: t.Callable[..., Page],
-    breadcrumb: str,
-    method_title: str,
-    method_signature: str,
-    method_description: str,
+    jsonrpc_page_info: t.Callable[..., Page], method_title: str, method_signature: str, method_description: str
 ) -> None:
-    jsonrpc_page_info('jsonrpc_basic.not_allow_notify', breadcrumb, method_title, method_signature, method_description)
+    jsonrpc_page_info('jsonrpc_basic.not_allow_notify', method_title, method_signature, method_description)
 
 
 @pytest.mark.parametrize(
@@ -302,17 +258,13 @@ def test_jsonrpc_basic_not_allow_notify_form(
 
 
 @pytest.mark.parametrize(
-    'breadcrumb,method_title,method_signature,method_description',
-    [('jsonrpc_basic » jsonrpc_basic.fails', 'jsonrpc_basic.fails', 'jsonrpc_basic.fails(n: Number) -> Number', '')],
+    'method_title,method_signature,method_description',
+    [('jsonrpc_basic.fails', 'jsonrpc_basic.fails(n: Number) -> Number', '')],
 )
 def test_jsonrpc_basic_fails_display(
-    jsonrpc_page_info: t.Callable[..., Page],
-    breadcrumb: str,
-    method_title: str,
-    method_signature: str,
-    method_description: str,
+    jsonrpc_page_info: t.Callable[..., Page], method_title: str, method_signature: str, method_description: str
 ) -> None:
-    jsonrpc_page_info('jsonrpc_basic.fails', breadcrumb, method_title, method_signature, method_description)
+    jsonrpc_page_info('jsonrpc_basic.fails', method_title, method_signature, method_description)
 
 
 @pytest.mark.parametrize(
@@ -376,24 +328,13 @@ def test_jsonrpc_basic_fails_form(
 
 
 @pytest.mark.parametrize(
-    'breadcrumb,method_title,method_signature,method_description',
-    [
-        (
-            'jsonrpc_basic » jsonrpc_basic.sum',
-            'jsonrpc_basic.sum',
-            'jsonrpc_basic.sum(a: Number, b: Number) -> Number',
-            '',
-        )
-    ],
+    'method_title,method_signature,method_description',
+    [('jsonrpc_basic.sum', 'jsonrpc_basic.sum(a: Number, b: Number) -> Number', '')],
 )
 def test_jsonrpc_basic_sum_display(
-    jsonrpc_page_info: t.Callable[..., Page],
-    breadcrumb: str,
-    method_title: str,
-    method_signature: str,
-    method_description: str,
+    jsonrpc_page_info: t.Callable[..., Page], method_title: str, method_signature: str, method_description: str
 ) -> None:
-    jsonrpc_page_info('jsonrpc_basic.sum', breadcrumb, method_title, method_signature, method_description)
+    jsonrpc_page_info('jsonrpc_basic.sum', method_title, method_signature, method_description)
 
 
 @pytest.mark.parametrize(
@@ -441,10 +382,9 @@ def test_jsonrpc_basic_sum_form(
 
 
 @pytest.mark.parametrize(
-    'breadcrumb,method_title,method_signature,method_description',
+    'method_title,method_signature,method_description',
     [
         (
-            'jsonrpc_basic » jsonrpc_basic.strangeEcho',
             'jsonrpc_basic.strangeEcho',
             (
                 'jsonrpc_basic.strangeEcho(string: String, omg: Object, wtf: Array, '
@@ -455,13 +395,9 @@ def test_jsonrpc_basic_sum_form(
     ],
 )
 def test_jsonrpc_basic_strange_echo_display(
-    jsonrpc_page_info: t.Callable[..., Page],
-    breadcrumb: str,
-    method_title: str,
-    method_signature: str,
-    method_description: str,
+    jsonrpc_page_info: t.Callable[..., Page], method_title: str, method_signature: str, method_description: str
 ) -> None:
-    jsonrpc_page_info('jsonrpc_basic.strangeEcho', breadcrumb, method_title, method_signature, method_description)
+    jsonrpc_page_info('jsonrpc_basic.strangeEcho', method_title, method_signature, method_description)
 
 
 @pytest.mark.parametrize(
@@ -570,24 +506,13 @@ def test_jsonrpc_basic_strange_echo_form(
 
 
 @pytest.mark.parametrize(
-    'breadcrumb,method_title,method_signature,method_description',
-    [
-        (
-            'jsonrpc_basic » jsonrpc_basic.noReturn',
-            'jsonrpc_basic.noReturn',
-            'jsonrpc_basic.noReturn(_string: String) -> Null',
-            '',
-        )
-    ],
+    'method_title,method_signature,method_description',
+    [('jsonrpc_basic.noReturn', 'jsonrpc_basic.noReturn(_string: String) -> Null', '')],
 )
 def test_jsonrpc_basic_no_return_display(
-    jsonrpc_page_info: t.Callable[..., Page],
-    breadcrumb: str,
-    method_title: str,
-    method_signature: str,
-    method_description: str,
+    jsonrpc_page_info: t.Callable[..., Page], method_title: str, method_signature: str, method_description: str
 ) -> None:
-    jsonrpc_page_info('jsonrpc_basic.noReturn', breadcrumb, method_title, method_signature, method_description)
+    jsonrpc_page_info('jsonrpc_basic.noReturn', method_title, method_signature, method_description)
 
 
 @pytest.mark.parametrize(

--- a/tests/integration/test_browse_pydantic_models.py
+++ b/tests/integration/test_browse_pydantic_models.py
@@ -31,26 +31,13 @@ from playwright.sync_api import Page
 
 
 @pytest.mark.parametrize(
-    'breadcrumb,method_title,method_signature,method_description',
-    [
-        (
-            'objects » objects.pydantic_models.createPet',
-            'objects.pydantic_models.createPet',
-            'objects.pydantic_models.createPet(pet: Object) -> Object',
-            '',
-        )
-    ],
+    'method_title,method_signature,method_description',
+    [('objects.pydantic_models.createPet', 'objects.pydantic_models.createPet(pet: Object) -> Object', '')],
 )
 def test_objects_pydantic_models_create_pet_display(
-    jsonrpc_page_info: t.Callable[..., Page],
-    breadcrumb: str,
-    method_title: str,
-    method_signature: str,
-    method_description: str,
+    jsonrpc_page_info: t.Callable[..., Page], method_title: str, method_signature: str, method_description: str
 ) -> None:
-    jsonrpc_page_info(
-        'objects.pydantic_models.createPet', breadcrumb, method_title, method_signature, method_description
-    )
+    jsonrpc_page_info('objects.pydantic_models.createPet', method_title, method_signature, method_description)
 
 
 @pytest.mark.parametrize(
@@ -125,10 +112,9 @@ def test_objects_pydantic_models_create_pet_form(
 
 
 @pytest.mark.parametrize(
-    'breadcrumb,method_title,method_signature,method_description',
+    'method_title,method_signature,method_description',
     [
         (
-            'objects » objects.pydantic_models.createManyPet',
             'objects.pydantic_models.createManyPet',
             'objects.pydantic_models.createManyPet(pets: Array, pet: Object) -> Array',
             '',
@@ -136,15 +122,9 @@ def test_objects_pydantic_models_create_pet_form(
     ],
 )
 def test_objects_pydantic_models_create_many_pet_display(
-    jsonrpc_page_info: t.Callable[..., Page],
-    breadcrumb: str,
-    method_title: str,
-    method_signature: str,
-    method_description: str,
+    jsonrpc_page_info: t.Callable[..., Page], method_title: str, method_signature: str, method_description: str
 ) -> None:
-    jsonrpc_page_info(
-        'objects.pydantic_models.createManyPet', breadcrumb, method_title, method_signature, method_description
-    )
+    jsonrpc_page_info('objects.pydantic_models.createManyPet', method_title, method_signature, method_description)
 
 
 @pytest.mark.parametrize(
@@ -249,10 +229,9 @@ def test_objects_pydantic_models_create_many_pet_form(
 
 
 @pytest.mark.parametrize(
-    'breadcrumb,method_title,method_signature,method_description',
+    'method_title,method_signature,method_description',
     [
         (
-            'objects » objects.pydantic_models.createManyFixPet',
             'objects.pydantic_models.createManyFixPet',
             'objects.pydantic_models.createManyFixPet(pets: Object) -> Array',
             '',
@@ -260,15 +239,9 @@ def test_objects_pydantic_models_create_many_pet_form(
     ],
 )
 def test_objects_pydantic_models_create_many_fix_pet_display(
-    jsonrpc_page_info: t.Callable[..., Page],
-    breadcrumb: str,
-    method_title: str,
-    method_signature: str,
-    method_description: str,
+    jsonrpc_page_info: t.Callable[..., Page], method_title: str, method_signature: str, method_description: str
 ) -> None:
-    jsonrpc_page_info(
-        'objects.pydantic_models.createManyFixPet', breadcrumb, method_title, method_signature, method_description
-    )
+    jsonrpc_page_info('objects.pydantic_models.createManyFixPet', method_title, method_signature, method_description)
 
 
 @pytest.mark.parametrize(
@@ -361,26 +334,13 @@ def test_objects_pydantic_models_create_many_fix_pet_form(
 
 
 @pytest.mark.parametrize(
-    'breadcrumb,method_title,method_signature,method_description',
-    [
-        (
-            'objects » objects.pydantic_models.removePet',
-            'objects.pydantic_models.removePet',
-            'objects.pydantic_models.removePet(pet: Object) -> Object',
-            '',
-        )
-    ],
+    'method_title,method_signature,method_description',
+    [('objects.pydantic_models.removePet', 'objects.pydantic_models.removePet(pet: Object) -> Object', '')],
 )
 def test_objects_pydantic_models_remove_pet_display(
-    jsonrpc_page_info: t.Callable[..., Page],
-    breadcrumb: str,
-    method_title: str,
-    method_signature: str,
-    method_description: str,
+    jsonrpc_page_info: t.Callable[..., Page], method_title: str, method_signature: str, method_description: str
 ) -> None:
-    jsonrpc_page_info(
-        'objects.pydantic_models.removePet', breadcrumb, method_title, method_signature, method_description
-    )
+    jsonrpc_page_info('objects.pydantic_models.removePet', method_title, method_signature, method_description)
 
 
 @pytest.mark.parametrize(

--- a/tests/integration/test_browse_pydantic_models_annotated.py
+++ b/tests/integration/test_browse_pydantic_models_annotated.py
@@ -31,10 +31,9 @@ from playwright.sync_api import Page
 
 
 @pytest.mark.parametrize(
-    'breadcrumb,method_title,method_signature,method_description',
+    'method_title,method_signature,method_description',
     [
         (
-            'types » types.pydantic_models_annotated.createPet',
             'types.pydantic_models_annotated.createPet',
             'types.pydantic_models_annotated.createPet(pet*: Object) -> Object',
             '',
@@ -42,15 +41,9 @@ from playwright.sync_api import Page
     ],
 )
 def test_types_pydantic_models_create_pet_display(
-    jsonrpc_page_info: t.Callable[..., Page],
-    breadcrumb: str,
-    method_title: str,
-    method_signature: str,
-    method_description: str,
+    jsonrpc_page_info: t.Callable[..., Page], method_title: str, method_signature: str, method_description: str
 ) -> None:
-    jsonrpc_page_info(
-        'types.pydantic_models_annotated.createPet', breadcrumb, method_title, method_signature, method_description
-    )
+    jsonrpc_page_info('types.pydantic_models_annotated.createPet', method_title, method_signature, method_description)
 
 
 @pytest.mark.parametrize(
@@ -125,10 +118,9 @@ def test_types_pydantic_models_create_pet_form(
 
 
 @pytest.mark.parametrize(
-    'breadcrumb,method_title,method_signature,method_description',
+    'method_title,method_signature,method_description',
     [
         (
-            'types » types.pydantic_models_annotated.createManyPet',
             'types.pydantic_models_annotated.createManyPet',
             'types.pydantic_models_annotated.createManyPet(pets*: Array, pet: Object) -> Array',
             '',
@@ -136,14 +128,10 @@ def test_types_pydantic_models_create_pet_form(
     ],
 )
 def test_types_pydantic_models_create_many_pet_display(
-    jsonrpc_page_info: t.Callable[..., Page],
-    breadcrumb: str,
-    method_title: str,
-    method_signature: str,
-    method_description: str,
+    jsonrpc_page_info: t.Callable[..., Page], method_title: str, method_signature: str, method_description: str
 ) -> None:
     jsonrpc_page_info(
-        'types.pydantic_models_annotated.createManyPet', breadcrumb, method_title, method_signature, method_description
+        'types.pydantic_models_annotated.createManyPet', method_title, method_signature, method_description
     )
 
 
@@ -263,10 +251,9 @@ def test_types_pydantic_models_create_many_pet_form(
 
 
 @pytest.mark.parametrize(
-    'breadcrumb,method_title,method_signature,method_description',
+    'method_title,method_signature,method_description',
     [
         (
-            'types » types.pydantic_models_annotated.createManyFixPet',
             'types.pydantic_models_annotated.createManyFixPet',
             'types.pydantic_models_annotated.createManyFixPet(pets*: Object) -> Array',
             '',
@@ -274,18 +261,10 @@ def test_types_pydantic_models_create_many_pet_form(
     ],
 )
 def test_types_pydantic_models_create_many_fix_pet_display(
-    jsonrpc_page_info: t.Callable[..., Page],
-    breadcrumb: str,
-    method_title: str,
-    method_signature: str,
-    method_description: str,
+    jsonrpc_page_info: t.Callable[..., Page], method_title: str, method_signature: str, method_description: str
 ) -> None:
     jsonrpc_page_info(
-        'types.pydantic_models_annotated.createManyFixPet',
-        breadcrumb,
-        method_title,
-        method_signature,
-        method_description,
+        'types.pydantic_models_annotated.createManyFixPet', method_title, method_signature, method_description
     )
 
 
@@ -393,10 +372,9 @@ def test_types_pydantic_models_create_many_fix_pet_form(
 
 
 @pytest.mark.parametrize(
-    'breadcrumb,method_title,method_signature,method_description',
+    'method_title,method_signature,method_description',
     [
         (
-            'types » types.pydantic_models_annotated.removePet',
             'types.pydantic_models_annotated.removePet',
             'types.pydantic_models_annotated.removePet(pet: Object) -> Object',
             '',
@@ -404,15 +382,9 @@ def test_types_pydantic_models_create_many_fix_pet_form(
     ],
 )
 def test_types_pydantic_models_remove_pet_display(
-    jsonrpc_page_info: t.Callable[..., Page],
-    breadcrumb: str,
-    method_title: str,
-    method_signature: str,
-    method_description: str,
+    jsonrpc_page_info: t.Callable[..., Page], method_title: str, method_signature: str, method_description: str
 ) -> None:
-    jsonrpc_page_info(
-        'types.pydantic_models_annotated.removePet', breadcrumb, method_title, method_signature, method_description
-    )
+    jsonrpc_page_info('types.pydantic_models_annotated.removePet', method_title, method_signature, method_description)
 
 
 @pytest.mark.parametrize(

--- a/tests/integration/test_browse_python_classes.py
+++ b/tests/integration/test_browse_python_classes.py
@@ -31,26 +31,13 @@ from playwright.sync_api import Page
 
 
 @pytest.mark.parametrize(
-    'breadcrumb,method_title,method_signature,method_description',
-    [
-        (
-            'objects » objects.python_classes.createColor',
-            'objects.python_classes.createColor',
-            'objects.python_classes.createColor(color: Object) -> Object',
-            '',
-        )
-    ],
+    'method_title,method_signature,method_description',
+    [('objects.python_classes.createColor', 'objects.python_classes.createColor(color: Object) -> Object', '')],
 )
 def test_python_classes_create_color_display(
-    jsonrpc_page_info: t.Callable[..., Page],
-    breadcrumb: str,
-    method_title: str,
-    method_signature: str,
-    method_description: str,
+    jsonrpc_page_info: t.Callable[..., Page], method_title: str, method_signature: str, method_description: str
 ) -> None:
-    jsonrpc_page_info(
-        'objects.python_classes.createColor', breadcrumb, method_title, method_signature, method_description
-    )
+    jsonrpc_page_info('objects.python_classes.createColor', method_title, method_signature, method_description)
 
 
 @pytest.mark.parametrize(
@@ -125,10 +112,9 @@ def test_python_classes_create_color_form(
 
 
 @pytest.mark.parametrize(
-    'breadcrumb,method_title,method_signature,method_description',
+    'method_title,method_signature,method_description',
     [
         (
-            'objects » objects.python_classes.createManyColor',
             'objects.python_classes.createManyColor',
             ('objects.python_classes.createManyColor(colors: Array, color: Object) -> Array'),
             '',
@@ -136,15 +122,9 @@ def test_python_classes_create_color_form(
     ],
 )
 def test_python_classes_create_many_color_display(
-    jsonrpc_page_info: t.Callable[..., Page],
-    breadcrumb: str,
-    method_title: str,
-    method_signature: str,
-    method_description: str,
+    jsonrpc_page_info: t.Callable[..., Page], method_title: str, method_signature: str, method_description: str
 ) -> None:
-    jsonrpc_page_info(
-        'objects.python_classes.createManyColor', breadcrumb, method_title, method_signature, method_description
-    )
+    jsonrpc_page_info('objects.python_classes.createManyColor', method_title, method_signature, method_description)
 
 
 @pytest.mark.parametrize(
@@ -252,10 +232,9 @@ def test_python_classes_create_many_color_form(
 
 
 @pytest.mark.parametrize(
-    'breadcrumb,method_title,method_signature,method_description',
+    'method_title,method_signature,method_description',
     [
         (
-            'objects » objects.python_classes.createManyFixColor',
             'objects.python_classes.createManyFixColor',
             'objects.python_classes.createManyFixColor(colors: Object) -> Array',
             '',
@@ -263,15 +242,9 @@ def test_python_classes_create_many_color_form(
     ],
 )
 def test_python_classes_create_many_fix_color_display(
-    jsonrpc_page_info: t.Callable[..., Page],
-    breadcrumb: str,
-    method_title: str,
-    method_signature: str,
-    method_description: str,
+    jsonrpc_page_info: t.Callable[..., Page], method_title: str, method_signature: str, method_description: str
 ) -> None:
-    jsonrpc_page_info(
-        'objects.python_classes.createManyFixColor', breadcrumb, method_title, method_signature, method_description
-    )
+    jsonrpc_page_info('objects.python_classes.createManyFixColor', method_title, method_signature, method_description)
 
 
 @pytest.mark.parametrize(
@@ -366,26 +339,13 @@ def test_python_classes_create_many_fix_color_form(
 
 
 @pytest.mark.parametrize(
-    'breadcrumb,method_title,method_signature,method_description',
-    [
-        (
-            'objects » objects.python_classes.removeColor',
-            'objects.python_classes.removeColor',
-            'objects.python_classes.removeColor(color: Object) -> Object',
-            '',
-        )
-    ],
+    'method_title,method_signature,method_description',
+    [('objects.python_classes.removeColor', 'objects.python_classes.removeColor(color: Object) -> Object', '')],
 )
 def test_python_classes_remove_color_display(
-    jsonrpc_page_info: t.Callable[..., Page],
-    breadcrumb: str,
-    method_title: str,
-    method_signature: str,
-    method_description: str,
+    jsonrpc_page_info: t.Callable[..., Page], method_title: str, method_signature: str, method_description: str
 ) -> None:
-    jsonrpc_page_info(
-        'objects.python_classes.removeColor', breadcrumb, method_title, method_signature, method_description
-    )
+    jsonrpc_page_info('objects.python_classes.removeColor', method_title, method_signature, method_description)
 
 
 @pytest.mark.parametrize(

--- a/tests/integration/test_browse_python_classes_annotated.py
+++ b/tests/integration/test_browse_python_classes_annotated.py
@@ -31,10 +31,9 @@ from playwright.sync_api import Page
 
 
 @pytest.mark.parametrize(
-    'breadcrumb,method_title,method_signature,method_description',
+    'method_title,method_signature,method_description',
     [
         (
-            'types » types.python_classes_annotated.createColor',
             'types.python_classes_annotated.createColor',
             'types.python_classes_annotated.createColor(color*: Object) -> Object',
             '',
@@ -42,15 +41,9 @@ from playwright.sync_api import Page
     ],
 )
 def test_python_classes_create_color_display(
-    jsonrpc_page_info: t.Callable[..., Page],
-    breadcrumb: str,
-    method_title: str,
-    method_signature: str,
-    method_description: str,
+    jsonrpc_page_info: t.Callable[..., Page], method_title: str, method_signature: str, method_description: str
 ) -> None:
-    jsonrpc_page_info(
-        'types.python_classes_annotated.createColor', breadcrumb, method_title, method_signature, method_description
-    )
+    jsonrpc_page_info('types.python_classes_annotated.createColor', method_title, method_signature, method_description)
 
 
 @pytest.mark.parametrize(
@@ -125,10 +118,9 @@ def test_python_classes_create_color_form(
 
 
 @pytest.mark.parametrize(
-    'breadcrumb,method_title,method_signature,method_description',
+    'method_title,method_signature,method_description',
     [
         (
-            'types » types.python_classes_annotated.createManyColor',
             'types.python_classes_annotated.createManyColor',
             ('types.python_classes_annotated.createManyColor(colors*: Array, color: Object) -> Array'),
             '',
@@ -136,14 +128,10 @@ def test_python_classes_create_color_form(
     ],
 )
 def test_python_classes_create_many_color_display(
-    jsonrpc_page_info: t.Callable[..., Page],
-    breadcrumb: str,
-    method_title: str,
-    method_signature: str,
-    method_description: str,
+    jsonrpc_page_info: t.Callable[..., Page], method_title: str, method_signature: str, method_description: str
 ) -> None:
     jsonrpc_page_info(
-        'types.python_classes_annotated.createManyColor', breadcrumb, method_title, method_signature, method_description
+        'types.python_classes_annotated.createManyColor', method_title, method_signature, method_description
     )
 
 
@@ -266,10 +254,9 @@ def test_python_classes_create_many_color_form(
 
 
 @pytest.mark.parametrize(
-    'breadcrumb,method_title,method_signature,method_description',
+    'method_title,method_signature,method_description',
     [
         (
-            'types » types.python_classes_annotated.createManyFixColor',
             'types.python_classes_annotated.createManyFixColor',
             'types.python_classes_annotated.createManyFixColor(colors*: Object) -> Array',
             '',
@@ -277,18 +264,10 @@ def test_python_classes_create_many_color_form(
     ],
 )
 def test_python_classes_create_many_fix_color_display(
-    jsonrpc_page_info: t.Callable[..., Page],
-    breadcrumb: str,
-    method_title: str,
-    method_signature: str,
-    method_description: str,
+    jsonrpc_page_info: t.Callable[..., Page], method_title: str, method_signature: str, method_description: str
 ) -> None:
     jsonrpc_page_info(
-        'types.python_classes_annotated.createManyFixColor',
-        breadcrumb,
-        method_title,
-        method_signature,
-        method_description,
+        'types.python_classes_annotated.createManyFixColor', method_title, method_signature, method_description
     )
 
 
@@ -398,10 +377,9 @@ def test_python_classes_create_many_fix_color_form(
 
 
 @pytest.mark.parametrize(
-    'breadcrumb,method_title,method_signature,method_description',
+    'method_title,method_signature,method_description',
     [
         (
-            'types » types.python_classes_annotated.removeColor',
             'types.python_classes_annotated.removeColor',
             'types.python_classes_annotated.removeColor(color: Object) -> Object',
             '',
@@ -409,15 +387,9 @@ def test_python_classes_create_many_fix_color_form(
     ],
 )
 def test_python_classes_remove_color_display(
-    jsonrpc_page_info: t.Callable[..., Page],
-    breadcrumb: str,
-    method_title: str,
-    method_signature: str,
-    method_description: str,
+    jsonrpc_page_info: t.Callable[..., Page], method_title: str, method_signature: str, method_description: str
 ) -> None:
-    jsonrpc_page_info(
-        'types.python_classes_annotated.removeColor', breadcrumb, method_title, method_signature, method_description
-    )
+    jsonrpc_page_info('types.python_classes_annotated.removeColor', method_title, method_signature, method_description)
 
 
 @pytest.mark.parametrize(

--- a/tests/integration/test_browse_python_dataclasses.py
+++ b/tests/integration/test_browse_python_dataclasses.py
@@ -31,26 +31,13 @@ from playwright.sync_api import Page
 
 
 @pytest.mark.parametrize(
-    'breadcrumb,method_title,method_signature,method_description',
-    [
-        (
-            'objects » objects.python_dataclasses.createCar',
-            'objects.python_dataclasses.createCar',
-            'objects.python_dataclasses.createCar(car: Object) -> Object',
-            '',
-        )
-    ],
+    'method_title,method_signature,method_description',
+    [('objects.python_dataclasses.createCar', 'objects.python_dataclasses.createCar(car: Object) -> Object', '')],
 )
 def test_objects_python_dataclasses_create_car_display(
-    jsonrpc_page_info: t.Callable[..., Page],
-    breadcrumb: str,
-    method_title: str,
-    method_signature: str,
-    method_description: str,
+    jsonrpc_page_info: t.Callable[..., Page], method_title: str, method_signature: str, method_description: str
 ) -> None:
-    jsonrpc_page_info(
-        'objects.python_dataclasses.createCar', breadcrumb, method_title, method_signature, method_description
-    )
+    jsonrpc_page_info('objects.python_dataclasses.createCar', method_title, method_signature, method_description)
 
 
 @pytest.mark.parametrize(
@@ -125,10 +112,9 @@ def test_objects_python_dataclasses_create_car_form(
 
 
 @pytest.mark.parametrize(
-    'breadcrumb,method_title,method_signature,method_description',
+    'method_title,method_signature,method_description',
     [
         (
-            'objects » objects.python_dataclasses.createManyCar',
             'objects.python_dataclasses.createManyCar',
             'objects.python_dataclasses.createManyCar(cars: Array, car: Object) -> Array',
             '',
@@ -136,15 +122,9 @@ def test_objects_python_dataclasses_create_car_form(
     ],
 )
 def test_objects_python_dataclasses_create_many_car_display(
-    jsonrpc_page_info: t.Callable[..., Page],
-    breadcrumb: str,
-    method_title: str,
-    method_signature: str,
-    method_description: str,
+    jsonrpc_page_info: t.Callable[..., Page], method_title: str, method_signature: str, method_description: str
 ) -> None:
-    jsonrpc_page_info(
-        'objects.python_dataclasses.createManyCar', breadcrumb, method_title, method_signature, method_description
-    )
+    jsonrpc_page_info('objects.python_dataclasses.createManyCar', method_title, method_signature, method_description)
 
 
 @pytest.mark.parametrize(
@@ -249,10 +229,9 @@ def test_objects_python_dataclasses_create_many_car_form(
 
 
 @pytest.mark.parametrize(
-    'breadcrumb,method_title,method_signature,method_description',
+    'method_title,method_signature,method_description',
     [
         (
-            'objects » objects.python_dataclasses.createManyFixCar',
             'objects.python_dataclasses.createManyFixCar',
             'objects.python_dataclasses.createManyFixCar(cars: Object) -> Array',
             '',
@@ -260,15 +239,9 @@ def test_objects_python_dataclasses_create_many_car_form(
     ],
 )
 def test_objects_python_dataclasses_create_many_fix_car_display(
-    jsonrpc_page_info: t.Callable[..., Page],
-    breadcrumb: str,
-    method_title: str,
-    method_signature: str,
-    method_description: str,
+    jsonrpc_page_info: t.Callable[..., Page], method_title: str, method_signature: str, method_description: str
 ) -> None:
-    jsonrpc_page_info(
-        'objects.python_dataclasses.createManyFixCar', breadcrumb, method_title, method_signature, method_description
-    )
+    jsonrpc_page_info('objects.python_dataclasses.createManyFixCar', method_title, method_signature, method_description)
 
 
 @pytest.mark.parametrize(
@@ -363,26 +336,13 @@ def test_objects_python_dataclasses_create_many_fix_car_form(
 
 
 @pytest.mark.parametrize(
-    'breadcrumb,method_title,method_signature,method_description',
-    [
-        (
-            'objects » objects.python_dataclasses.removeCar',
-            'objects.python_dataclasses.removeCar',
-            'objects.python_dataclasses.removeCar(car: Object) -> Object',
-            '',
-        )
-    ],
+    'method_title,method_signature,method_description',
+    [('objects.python_dataclasses.removeCar', 'objects.python_dataclasses.removeCar(car: Object) -> Object', '')],
 )
 def test_objects_python_dataclasses_remove_car_display(
-    jsonrpc_page_info: t.Callable[..., Page],
-    breadcrumb: str,
-    method_title: str,
-    method_signature: str,
-    method_description: str,
+    jsonrpc_page_info: t.Callable[..., Page], method_title: str, method_signature: str, method_description: str
 ) -> None:
-    jsonrpc_page_info(
-        'objects.python_dataclasses.removeCar', breadcrumb, method_title, method_signature, method_description
-    )
+    jsonrpc_page_info('objects.python_dataclasses.removeCar', method_title, method_signature, method_description)
 
 
 @pytest.mark.parametrize(

--- a/tests/integration/test_browse_python_dataclasses_annotated.py
+++ b/tests/integration/test_browse_python_dataclasses_annotated.py
@@ -31,10 +31,9 @@ from playwright.sync_api import Page
 
 
 @pytest.mark.parametrize(
-    'breadcrumb,method_title,method_signature,method_description',
+    'method_title,method_signature,method_description',
     [
         (
-            'types » types.python_dataclasses_annotated.createCar',
             'types.python_dataclasses_annotated.createCar',
             'types.python_dataclasses_annotated.createCar(car*: Object) -> Object',
             '',
@@ -42,14 +41,10 @@ from playwright.sync_api import Page
     ],
 )
 def test_types_python_dataclasses_create_car_display(
-    jsonrpc_page_info: t.Callable[..., Page],
-    breadcrumb: str,
-    method_title: str,
-    method_signature: str,
-    method_description: str,
+    jsonrpc_page_info: t.Callable[..., Page], method_title: str, method_signature: str, method_description: str
 ) -> None:
     jsonrpc_page_info(
-        'types.python_dataclasses_annotated.createCar', breadcrumb, method_title, method_signature, method_description
+        'types.python_dataclasses_annotated.createCar', method_title, method_signature, method_description
     )
 
 
@@ -125,10 +120,9 @@ def test_types_python_dataclasses_create_car_form(
 
 
 @pytest.mark.parametrize(
-    'breadcrumb,method_title,method_signature,method_description',
+    'method_title,method_signature,method_description',
     [
         (
-            'types » types.python_dataclasses_annotated.createManyCar',
             'types.python_dataclasses_annotated.createManyCar',
             'types.python_dataclasses_annotated.createManyCar(cars*: Array, car: Object) -> Array',
             '',
@@ -136,18 +130,10 @@ def test_types_python_dataclasses_create_car_form(
     ],
 )
 def test_types_python_dataclasses_create_many_car_display(
-    jsonrpc_page_info: t.Callable[..., Page],
-    breadcrumb: str,
-    method_title: str,
-    method_signature: str,
-    method_description: str,
+    jsonrpc_page_info: t.Callable[..., Page], method_title: str, method_signature: str, method_description: str
 ) -> None:
     jsonrpc_page_info(
-        'types.python_dataclasses_annotated.createManyCar',
-        breadcrumb,
-        method_title,
-        method_signature,
-        method_description,
+        'types.python_dataclasses_annotated.createManyCar', method_title, method_signature, method_description
     )
 
 
@@ -267,10 +253,9 @@ def test_types_python_dataclasses_create_many_car_form(
 
 
 @pytest.mark.parametrize(
-    'breadcrumb,method_title,method_signature,method_description',
+    'method_title,method_signature,method_description',
     [
         (
-            'types » types.python_dataclasses_annotated.createManyFixCar',
             'types.python_dataclasses_annotated.createManyFixCar',
             'types.python_dataclasses_annotated.createManyFixCar(cars*: Object) -> Array',
             '',
@@ -278,18 +263,10 @@ def test_types_python_dataclasses_create_many_car_form(
     ],
 )
 def test_types_python_dataclasses_create_many_fix_car_display(
-    jsonrpc_page_info: t.Callable[..., Page],
-    breadcrumb: str,
-    method_title: str,
-    method_signature: str,
-    method_description: str,
+    jsonrpc_page_info: t.Callable[..., Page], method_title: str, method_signature: str, method_description: str
 ) -> None:
     jsonrpc_page_info(
-        'types.python_dataclasses_annotated.createManyFixCar',
-        breadcrumb,
-        method_title,
-        method_signature,
-        method_description,
+        'types.python_dataclasses_annotated.createManyFixCar', method_title, method_signature, method_description
     )
 
 
@@ -399,10 +376,9 @@ def test_types_python_dataclasses_create_many_fix_car_form(
 
 
 @pytest.mark.parametrize(
-    'breadcrumb,method_title,method_signature,method_description',
+    'method_title,method_signature,method_description',
     [
         (
-            'types » types.python_dataclasses_annotated.removeCar',
             'types.python_dataclasses_annotated.removeCar',
             'types.python_dataclasses_annotated.removeCar(car: Object) -> Object',
             '',
@@ -410,14 +386,10 @@ def test_types_python_dataclasses_create_many_fix_car_form(
     ],
 )
 def test_types_python_dataclasses_remove_car_display(
-    jsonrpc_page_info: t.Callable[..., Page],
-    breadcrumb: str,
-    method_title: str,
-    method_signature: str,
-    method_description: str,
+    jsonrpc_page_info: t.Callable[..., Page], method_title: str, method_signature: str, method_description: str
 ) -> None:
     jsonrpc_page_info(
-        'types.python_dataclasses_annotated.removeCar', breadcrumb, method_title, method_signature, method_description
+        'types.python_dataclasses_annotated.removeCar', method_title, method_signature, method_description
     )
 
 

--- a/tests/integration/test_browse_python_stds.py
+++ b/tests/integration/test_browse_python_stds.py
@@ -31,24 +31,13 @@ from playwright.sync_api import Page
 
 
 @pytest.mark.parametrize(
-    'breadcrumb,method_title,method_signature,method_description',
-    [
-        (
-            'types » types.python_stds.boolType',
-            'types.python_stds.boolType',
-            'types.python_stds.boolType(yes: Boolean) -> Boolean',
-            '',
-        )
-    ],
+    'method_title,method_signature,method_description',
+    [('types.python_stds.boolType', 'types.python_stds.boolType(yes: Boolean) -> Boolean', '')],
 )
 def test_types_python_stds_bool_type_display(
-    jsonrpc_page_info: t.Callable[..., Page],
-    breadcrumb: str,
-    method_title: str,
-    method_signature: str,
-    method_description: str,
+    jsonrpc_page_info: t.Callable[..., Page], method_title: str, method_signature: str, method_description: str
 ) -> None:
-    jsonrpc_page_info('types.python_stds.boolType', breadcrumb, method_title, method_signature, method_description)
+    jsonrpc_page_info('types.python_stds.boolType', method_title, method_signature, method_description)
 
 
 @pytest.mark.parametrize(
@@ -96,24 +85,13 @@ def test_types_python_stds_bool_type_form(
 
 
 @pytest.mark.parametrize(
-    'breadcrumb,method_title,method_signature,method_description',
-    [
-        (
-            'types » types.python_stds.strType',
-            'types.python_stds.strType',
-            'types.python_stds.strType(st: String) -> String',
-            '',
-        )
-    ],
+    'method_title,method_signature,method_description',
+    [('types.python_stds.strType', 'types.python_stds.strType(st: String) -> String', '')],
 )
 def test_types_python_stds_str_type_display(
-    jsonrpc_page_info: t.Callable[..., Page],
-    breadcrumb: str,
-    method_title: str,
-    method_signature: str,
-    method_description: str,
+    jsonrpc_page_info: t.Callable[..., Page], method_title: str, method_signature: str, method_description: str
 ) -> None:
-    jsonrpc_page_info('types.python_stds.strType', breadcrumb, method_title, method_signature, method_description)
+    jsonrpc_page_info('types.python_stds.strType', method_title, method_signature, method_description)
 
 
 @pytest.mark.parametrize(
@@ -177,24 +155,13 @@ def test_types_python_stds_str_type_form(
 
 
 @pytest.mark.parametrize(
-    'breadcrumb,method_title,method_signature,method_description',
-    [
-        (
-            'types » types.python_stds.intType',
-            'types.python_stds.intType',
-            'types.python_stds.intType(n: Number) -> Number',
-            '',
-        )
-    ],
+    'method_title,method_signature,method_description',
+    [('types.python_stds.intType', 'types.python_stds.intType(n: Number) -> Number', '')],
 )
 def test_types_python_stds_int_type_display(
-    jsonrpc_page_info: t.Callable[..., Page],
-    breadcrumb: str,
-    method_title: str,
-    method_signature: str,
-    method_description: str,
+    jsonrpc_page_info: t.Callable[..., Page], method_title: str, method_signature: str, method_description: str
 ) -> None:
-    jsonrpc_page_info('types.python_stds.intType', breadcrumb, method_title, method_signature, method_description)
+    jsonrpc_page_info('types.python_stds.intType', method_title, method_signature, method_description)
 
 
 @pytest.mark.parametrize(
@@ -242,24 +209,13 @@ def test_types_python_stds_int_type_form(
 
 
 @pytest.mark.parametrize(
-    'breadcrumb,method_title,method_signature,method_description',
-    [
-        (
-            'types » types.python_stds.floatType',
-            'types.python_stds.floatType',
-            'types.python_stds.floatType(n: Number) -> Number',
-            '',
-        )
-    ],
+    'method_title,method_signature,method_description',
+    [('types.python_stds.floatType', 'types.python_stds.floatType(n: Number) -> Number', '')],
 )
 def test_types_python_stds_float_type_display(
-    jsonrpc_page_info: t.Callable[..., Page],
-    breadcrumb: str,
-    method_title: str,
-    method_signature: str,
-    method_description: str,
+    jsonrpc_page_info: t.Callable[..., Page], method_title: str, method_signature: str, method_description: str
 ) -> None:
-    jsonrpc_page_info('types.python_stds.floatType', breadcrumb, method_title, method_signature, method_description)
+    jsonrpc_page_info('types.python_stds.floatType', method_title, method_signature, method_description)
 
 
 @pytest.mark.parametrize(
@@ -307,24 +263,13 @@ def test_types_python_stds_float_type_form(
 
 
 @pytest.mark.parametrize(
-    'breadcrumb,method_title,method_signature,method_description',
-    [
-        (
-            'types » types.python_stds.listType',
-            'types.python_stds.listType',
-            'types.python_stds.listType(lst: Array) -> Array',
-            '',
-        )
-    ],
+    'method_title,method_signature,method_description',
+    [('types.python_stds.listType', 'types.python_stds.listType(lst: Array) -> Array', '')],
 )
 def test_types_python_stds_list_type_display(
-    jsonrpc_page_info: t.Callable[..., Page],
-    breadcrumb: str,
-    method_title: str,
-    method_signature: str,
-    method_description: str,
+    jsonrpc_page_info: t.Callable[..., Page], method_title: str, method_signature: str, method_description: str
 ) -> None:
-    jsonrpc_page_info('types.python_stds.listType', breadcrumb, method_title, method_signature, method_description)
+    jsonrpc_page_info('types.python_stds.listType', method_title, method_signature, method_description)
 
 
 @pytest.mark.parametrize(
@@ -396,24 +341,13 @@ def test_types_python_stds_list_type_form(
 
 
 @pytest.mark.parametrize(
-    'breadcrumb,method_title,method_signature,method_description',
-    [
-        (
-            'types » types.python_stds.dictType',
-            'types.python_stds.dictType',
-            'types.python_stds.dictType(d: Object) -> Object',
-            '',
-        )
-    ],
+    'method_title,method_signature,method_description',
+    [('types.python_stds.dictType', 'types.python_stds.dictType(d: Object) -> Object', '')],
 )
 def test_types_python_stds_dict_type_display(
-    jsonrpc_page_info: t.Callable[..., Page],
-    breadcrumb: str,
-    method_title: str,
-    method_signature: str,
-    method_description: str,
+    jsonrpc_page_info: t.Callable[..., Page], method_title: str, method_signature: str, method_description: str
 ) -> None:
-    jsonrpc_page_info('types.python_stds.dictType', breadcrumb, method_title, method_signature, method_description)
+    jsonrpc_page_info('types.python_stds.dictType', method_title, method_signature, method_description)
 
 
 @pytest.mark.parametrize(
@@ -465,24 +399,13 @@ def test_types_python_stds_dict_type_form(
 
 
 @pytest.mark.parametrize(
-    'breadcrumb,method_title,method_signature,method_description',
-    [
-        (
-            'types » types.python_stds.bytesType',
-            'types.python_stds.bytesType',
-            'types.python_stds.bytesType(b: String) -> String',
-            '',
-        )
-    ],
+    'method_title,method_signature,method_description',
+    [('types.python_stds.bytesType', 'types.python_stds.bytesType(b: String) -> String', '')],
 )
 def test_types_python_bytes_type_display(
-    jsonrpc_page_info: t.Callable[..., Page],
-    breadcrumb: str,
-    method_title: str,
-    method_signature: str,
-    method_description: str,
+    jsonrpc_page_info: t.Callable[..., Page], method_title: str, method_signature: str, method_description: str
 ) -> None:
-    jsonrpc_page_info('types.python_stds.bytesType', breadcrumb, method_title, method_signature, method_description)
+    jsonrpc_page_info('types.python_stds.bytesType', method_title, method_signature, method_description)
 
 
 @pytest.mark.parametrize(
@@ -542,24 +465,13 @@ def test_types_python_bytes_type_form(
 
 
 @pytest.mark.parametrize(
-    'breadcrumb,method_title,method_signature,method_description',
-    [
-        (
-            'types » types.python_stds.bytearrayType',
-            'types.python_stds.bytearrayType',
-            'types.python_stds.bytearrayType(b: String) -> String',
-            '',
-        )
-    ],
+    'method_title,method_signature,method_description',
+    [('types.python_stds.bytearrayType', 'types.python_stds.bytearrayType(b: String) -> String', '')],
 )
 def test_types_python_bytearray_type_display(
-    jsonrpc_page_info: t.Callable[..., Page],
-    breadcrumb: str,
-    method_title: str,
-    method_signature: str,
-    method_description: str,
+    jsonrpc_page_info: t.Callable[..., Page], method_title: str, method_signature: str, method_description: str
 ) -> None:
-    jsonrpc_page_info('types.python_stds.bytearrayType', breadcrumb, method_title, method_signature, method_description)
+    jsonrpc_page_info('types.python_stds.bytearrayType', method_title, method_signature, method_description)
 
 
 @pytest.mark.parametrize(
@@ -615,24 +527,13 @@ def test_types_python_bytearray_type_form(
 
 
 @pytest.mark.parametrize(
-    'breadcrumb,method_title,method_signature,method_description',
-    [
-        (
-            'types » types.python_stds.intEnumType',
-            'types.python_stds.intEnumType',
-            'types.python_stds.intEnumType(e: Object) -> Object',
-            '',
-        )
-    ],
+    'method_title,method_signature,method_description',
+    [('types.python_stds.intEnumType', 'types.python_stds.intEnumType(e: Object) -> Object', '')],
 )
 def test_types_python_int_enum_type_display(
-    jsonrpc_page_info: t.Callable[..., Page],
-    breadcrumb: str,
-    method_title: str,
-    method_signature: str,
-    method_description: str,
+    jsonrpc_page_info: t.Callable[..., Page], method_title: str, method_signature: str, method_description: str
 ) -> None:
-    jsonrpc_page_info('types.python_stds.intEnumType', breadcrumb, method_title, method_signature, method_description)
+    jsonrpc_page_info('types.python_stds.intEnumType', method_title, method_signature, method_description)
 
 
 @pytest.mark.parametrize(
@@ -696,24 +597,13 @@ def test_types_python_int_enum_type_form(
 
 
 @pytest.mark.parametrize(
-    'breadcrumb,method_title,method_signature,method_description',
-    [
-        (
-            'types » types.python_stds.decimalType',
-            'types.python_stds.decimalType',
-            'types.python_stds.decimalType(n: Number) -> Number',
-            '',
-        )
-    ],
+    'method_title,method_signature,method_description',
+    [('types.python_stds.decimalType', 'types.python_stds.decimalType(n: Number) -> Number', '')],
 )
 def test_types_python_decimal_type_display(
-    jsonrpc_page_info: t.Callable[..., Page],
-    breadcrumb: str,
-    method_title: str,
-    method_signature: str,
-    method_description: str,
+    jsonrpc_page_info: t.Callable[..., Page], method_title: str, method_signature: str, method_description: str
 ) -> None:
-    jsonrpc_page_info('types.python_stds.decimalType', breadcrumb, method_title, method_signature, method_description)
+    jsonrpc_page_info('types.python_stds.decimalType', method_title, method_signature, method_description)
 
 
 @pytest.mark.parametrize(
@@ -761,24 +651,13 @@ def test_types_python_decimal_type_form(
 
 
 @pytest.mark.parametrize(
-    'breadcrumb,method_title,method_signature,method_description',
-    [
-        (
-            'types » types.python_stds.tupleType',
-            'types.python_stds.tupleType',
-            'types.python_stds.tupleType(tn: Array) -> Array',
-            '',
-        )
-    ],
+    'method_title,method_signature,method_description',
+    [('types.python_stds.tupleType', 'types.python_stds.tupleType(tn: Array) -> Array', '')],
 )
 def test_types_python_tuple_type_display(
-    jsonrpc_page_info: t.Callable[..., Page],
-    breadcrumb: str,
-    method_title: str,
-    method_signature: str,
-    method_description: str,
+    jsonrpc_page_info: t.Callable[..., Page], method_title: str, method_signature: str, method_description: str
 ) -> None:
-    jsonrpc_page_info('types.python_stds.tupleType', breadcrumb, method_title, method_signature, method_description)
+    jsonrpc_page_info('types.python_stds.tupleType', method_title, method_signature, method_description)
 
 
 @pytest.mark.parametrize(
@@ -826,26 +705,13 @@ def test_types_python_tuple_type_form(
 
 
 @pytest.mark.parametrize(
-    'breadcrumb,method_title,method_signature,method_description',
-    [
-        (
-            'types » types.python_stds.namedtupleType',
-            'types.python_stds.namedtupleType',
-            'types.python_stds.namedtupleType(tn: Object) -> Array',
-            '',
-        )
-    ],
+    'method_title,method_signature,method_description',
+    [('types.python_stds.namedtupleType', 'types.python_stds.namedtupleType(tn: Object) -> Array', '')],
 )
 def test_types_python_namedtuple_type_display(
-    jsonrpc_page_info: t.Callable[..., Page],
-    breadcrumb: str,
-    method_title: str,
-    method_signature: str,
-    method_description: str,
+    jsonrpc_page_info: t.Callable[..., Page], method_title: str, method_signature: str, method_description: str
 ) -> None:
-    jsonrpc_page_info(
-        'types.python_stds.namedtupleType', breadcrumb, method_title, method_signature, method_description
-    )
+    jsonrpc_page_info('types.python_stds.namedtupleType', method_title, method_signature, method_description)
 
 
 @pytest.mark.parametrize(
@@ -913,24 +779,13 @@ def test_types_python_namedtuple_type_form(
 
 
 @pytest.mark.parametrize(
-    'breadcrumb,method_title,method_signature,method_description',
-    [
-        (
-            'types » types.python_stds.setType',
-            'types.python_stds.setType',
-            'types.python_stds.setType(s: Array) -> Array',
-            '',
-        )
-    ],
+    'method_title,method_signature,method_description',
+    [('types.python_stds.setType', 'types.python_stds.setType(s: Array) -> Array', '')],
 )
 def test_types_python_set_type_display(
-    jsonrpc_page_info: t.Callable[..., Page],
-    breadcrumb: str,
-    method_title: str,
-    method_signature: str,
-    method_description: str,
+    jsonrpc_page_info: t.Callable[..., Page], method_title: str, method_signature: str, method_description: str
 ) -> None:
-    jsonrpc_page_info('types.python_stds.setType', breadcrumb, method_title, method_signature, method_description)
+    jsonrpc_page_info('types.python_stds.setType', method_title, method_signature, method_description)
 
 
 @pytest.mark.parametrize(
@@ -978,24 +833,13 @@ def test_types_python_set_type_form(
 
 
 @pytest.mark.parametrize(
-    'breadcrumb,method_title,method_signature,method_description',
-    [
-        (
-            'types » types.python_stds.sequenceType',
-            'types.python_stds.sequenceType',
-            'types.python_stds.sequenceType(s: Array) -> Array',
-            '',
-        )
-    ],
+    'method_title,method_signature,method_description',
+    [('types.python_stds.sequenceType', 'types.python_stds.sequenceType(s: Array) -> Array', '')],
 )
 def test_types_python_sequence_type_display(
-    jsonrpc_page_info: t.Callable[..., Page],
-    breadcrumb: str,
-    method_title: str,
-    method_signature: str,
-    method_description: str,
+    jsonrpc_page_info: t.Callable[..., Page], method_title: str, method_signature: str, method_description: str
 ) -> None:
-    jsonrpc_page_info('types.python_stds.sequenceType', breadcrumb, method_title, method_signature, method_description)
+    jsonrpc_page_info('types.python_stds.sequenceType', method_title, method_signature, method_description)
 
 
 @pytest.mark.parametrize(
@@ -1043,24 +887,13 @@ def test_types_python_sequence_type_form(
 
 
 @pytest.mark.parametrize(
-    'breadcrumb,method_title,method_signature,method_description',
-    [
-        (
-            'types » types.python_stds.typedDictType',
-            'types.python_stds.typedDictType',
-            'types.python_stds.typedDictType(user: Object) -> Object',
-            '',
-        )
-    ],
+    'method_title,method_signature,method_description',
+    [('types.python_stds.typedDictType', 'types.python_stds.typedDictType(user: Object) -> Object', '')],
 )
 def test_types_python_typed_dict_type_display(
-    jsonrpc_page_info: t.Callable[..., Page],
-    breadcrumb: str,
-    method_title: str,
-    method_signature: str,
-    method_description: str,
+    jsonrpc_page_info: t.Callable[..., Page], method_title: str, method_signature: str, method_description: str
 ) -> None:
-    jsonrpc_page_info('types.python_stds.typedDictType', breadcrumb, method_title, method_signature, method_description)
+    jsonrpc_page_info('types.python_stds.typedDictType', method_title, method_signature, method_description)
 
 
 @pytest.mark.parametrize(
@@ -1132,26 +965,13 @@ def test_types_python_typed_dict_type_form(
 
 
 @pytest.mark.parametrize(
-    'breadcrumb,method_title,method_signature,method_description',
-    [
-        (
-            'types » types.python_stds.unionWithTwoTypes',
-            'types.python_stds.unionWithTwoTypes',
-            'types.python_stds.unionWithTwoTypes(n: Number) -> Number',
-            '',
-        )
-    ],
+    'method_title,method_signature,method_description',
+    [('types.python_stds.unionWithTwoTypes', 'types.python_stds.unionWithTwoTypes(n: Number) -> Number', '')],
 )
 def test_types_python_union_with_two_types_display(
-    jsonrpc_page_info: t.Callable[..., Page],
-    breadcrumb: str,
-    method_title: str,
-    method_signature: str,
-    method_description: str,
+    jsonrpc_page_info: t.Callable[..., Page], method_title: str, method_signature: str, method_description: str
 ) -> None:
-    jsonrpc_page_info(
-        'types.python_stds.unionWithTwoTypes', breadcrumb, method_title, method_signature, method_description
-    )
+    jsonrpc_page_info('types.python_stds.unionWithTwoTypes', method_title, method_signature, method_description)
 
 
 @pytest.mark.parametrize(
@@ -1217,24 +1037,13 @@ def test_types_python_union_with_two_types_form(
 
 
 @pytest.mark.parametrize(
-    'breadcrumb,method_title,method_signature,method_description',
-    [
-        (
-            'types » types.python_stds.literalType',
-            'types.python_stds.literalType',
-            'types.python_stds.literalType(x: String) -> String',
-            '',
-        )
-    ],
+    'method_title,method_signature,method_description',
+    [('types.python_stds.literalType', 'types.python_stds.literalType(x: String) -> String', '')],
 )
 def test_types_python_literal_type_display(
-    jsonrpc_page_info: t.Callable[..., Page],
-    breadcrumb: str,
-    method_title: str,
-    method_signature: str,
-    method_description: str,
+    jsonrpc_page_info: t.Callable[..., Page], method_title: str, method_signature: str, method_description: str
 ) -> None:
-    jsonrpc_page_info('types.python_stds.literalType', breadcrumb, method_title, method_signature, method_description)
+    jsonrpc_page_info('types.python_stds.literalType', method_title, method_signature, method_description)
 
 
 @pytest.mark.parametrize(
@@ -1282,24 +1091,13 @@ def test_types_python_literal_type_form(
 
 
 @pytest.mark.parametrize(
-    'breadcrumb,method_title,method_signature,method_description',
-    [
-        (
-            'types » types.python_stds.optional',
-            'types.python_stds.optional',
-            'types.python_stds.optional(n: Number) -> Number',
-            '',
-        )
-    ],
+    'method_title,method_signature,method_description',
+    [('types.python_stds.optional', 'types.python_stds.optional(n: Number) -> Number', '')],
 )
 def test_types_python_optional_display(
-    jsonrpc_page_info: t.Callable[..., Page],
-    breadcrumb: str,
-    method_title: str,
-    method_signature: str,
-    method_description: str,
+    jsonrpc_page_info: t.Callable[..., Page], method_title: str, method_signature: str, method_description: str
 ) -> None:
-    jsonrpc_page_info('types.python_stds.optional', breadcrumb, method_title, method_signature, method_description)
+    jsonrpc_page_info('types.python_stds.optional', method_title, method_signature, method_description)
 
 
 @pytest.mark.parametrize(

--- a/tests/integration/test_browse_python_stds_annotated.py
+++ b/tests/integration/test_browse_python_stds_annotated.py
@@ -31,26 +31,13 @@ from playwright.sync_api import Page
 
 
 @pytest.mark.parametrize(
-    'breadcrumb,method_title,method_signature,method_description',
-    [
-        (
-            'types » types.python_stds_annotated.boolType',
-            'types.python_stds_annotated.boolType',
-            'types.python_stds_annotated.boolType(yes*: Boolean) -> Boolean',
-            '',
-        )
-    ],
+    'method_title,method_signature,method_description',
+    [('types.python_stds_annotated.boolType', 'types.python_stds_annotated.boolType(yes*: Boolean) -> Boolean', '')],
 )
 def test_types_python_stds_bool_type_display(
-    jsonrpc_page_info: t.Callable[..., Page],
-    breadcrumb: str,
-    method_title: str,
-    method_signature: str,
-    method_description: str,
+    jsonrpc_page_info: t.Callable[..., Page], method_title: str, method_signature: str, method_description: str
 ) -> None:
-    jsonrpc_page_info(
-        'types.python_stds_annotated.boolType', breadcrumb, method_title, method_signature, method_description
-    )
+    jsonrpc_page_info('types.python_stds_annotated.boolType', method_title, method_signature, method_description)
 
 
 @pytest.mark.parametrize(
@@ -78,26 +65,13 @@ def test_types_python_stds_bool_type_form(
 
 
 @pytest.mark.parametrize(
-    'breadcrumb,method_title,method_signature,method_description',
-    [
-        (
-            'types » types.python_stds_annotated.strType',
-            'types.python_stds_annotated.strType',
-            'types.python_stds_annotated.strType(st*: String) -> String',
-            '',
-        )
-    ],
+    'method_title,method_signature,method_description',
+    [('types.python_stds_annotated.strType', 'types.python_stds_annotated.strType(st*: String) -> String', '')],
 )
 def test_types_python_stds_str_type_display(
-    jsonrpc_page_info: t.Callable[..., Page],
-    breadcrumb: str,
-    method_title: str,
-    method_signature: str,
-    method_description: str,
+    jsonrpc_page_info: t.Callable[..., Page], method_title: str, method_signature: str, method_description: str
 ) -> None:
-    jsonrpc_page_info(
-        'types.python_stds_annotated.strType', breadcrumb, method_title, method_signature, method_description
-    )
+    jsonrpc_page_info('types.python_stds_annotated.strType', method_title, method_signature, method_description)
 
 
 @pytest.mark.parametrize(
@@ -171,26 +145,13 @@ def test_types_python_stds_str_type_form(
 
 
 @pytest.mark.parametrize(
-    'breadcrumb,method_title,method_signature,method_description',
-    [
-        (
-            'types » types.python_stds_annotated.intType',
-            'types.python_stds_annotated.intType',
-            'types.python_stds_annotated.intType(n*: Number) -> Number',
-            '',
-        )
-    ],
+    'method_title,method_signature,method_description',
+    [('types.python_stds_annotated.intType', 'types.python_stds_annotated.intType(n*: Number) -> Number', '')],
 )
 def test_types_python_stds_int_type_display(
-    jsonrpc_page_info: t.Callable[..., Page],
-    breadcrumb: str,
-    method_title: str,
-    method_signature: str,
-    method_description: str,
+    jsonrpc_page_info: t.Callable[..., Page], method_title: str, method_signature: str, method_description: str
 ) -> None:
-    jsonrpc_page_info(
-        'types.python_stds_annotated.intType', breadcrumb, method_title, method_signature, method_description
-    )
+    jsonrpc_page_info('types.python_stds_annotated.intType', method_title, method_signature, method_description)
 
 
 @pytest.mark.parametrize(
@@ -266,26 +227,13 @@ def test_types_python_stds_int_type_form(
 
 
 @pytest.mark.parametrize(
-    'breadcrumb,method_title,method_signature,method_description',
-    [
-        (
-            'types » types.python_stds_annotated.floatType',
-            'types.python_stds_annotated.floatType',
-            'types.python_stds_annotated.floatType(n*: Number) -> Number',
-            '',
-        )
-    ],
+    'method_title,method_signature,method_description',
+    [('types.python_stds_annotated.floatType', 'types.python_stds_annotated.floatType(n*: Number) -> Number', '')],
 )
 def test_types_python_stds_float_type_display(
-    jsonrpc_page_info: t.Callable[..., Page],
-    breadcrumb: str,
-    method_title: str,
-    method_signature: str,
-    method_description: str,
+    jsonrpc_page_info: t.Callable[..., Page], method_title: str, method_signature: str, method_description: str
 ) -> None:
-    jsonrpc_page_info(
-        'types.python_stds_annotated.floatType', breadcrumb, method_title, method_signature, method_description
-    )
+    jsonrpc_page_info('types.python_stds_annotated.floatType', method_title, method_signature, method_description)
 
 
 @pytest.mark.parametrize(
@@ -391,26 +339,13 @@ def test_types_python_stds_float_type_form(
 
 
 @pytest.mark.parametrize(
-    'breadcrumb,method_title,method_signature,method_description',
-    [
-        (
-            'types » types.python_stds_annotated.listType',
-            'types.python_stds_annotated.listType',
-            'types.python_stds_annotated.listType(lst*: Array) -> Array',
-            '',
-        )
-    ],
+    'method_title,method_signature,method_description',
+    [('types.python_stds_annotated.listType', 'types.python_stds_annotated.listType(lst*: Array) -> Array', '')],
 )
 def test_types_python_stds_list_type_display(
-    jsonrpc_page_info: t.Callable[..., Page],
-    breadcrumb: str,
-    method_title: str,
-    method_signature: str,
-    method_description: str,
+    jsonrpc_page_info: t.Callable[..., Page], method_title: str, method_signature: str, method_description: str
 ) -> None:
-    jsonrpc_page_info(
-        'types.python_stds_annotated.listType', breadcrumb, method_title, method_signature, method_description
-    )
+    jsonrpc_page_info('types.python_stds_annotated.listType', method_title, method_signature, method_description)
 
 
 @pytest.mark.parametrize(
@@ -500,26 +435,13 @@ def test_types_python_stds_list_type_form(
 
 
 @pytest.mark.parametrize(
-    'breadcrumb,method_title,method_signature,method_description',
-    [
-        (
-            'types » types.python_stds_annotated.dictType',
-            'types.python_stds_annotated.dictType',
-            'types.python_stds_annotated.dictType(d*: Object) -> Object',
-            '',
-        )
-    ],
+    'method_title,method_signature,method_description',
+    [('types.python_stds_annotated.dictType', 'types.python_stds_annotated.dictType(d*: Object) -> Object', '')],
 )
 def test_types_python_stds_dict_type_display(
-    jsonrpc_page_info: t.Callable[..., Page],
-    breadcrumb: str,
-    method_title: str,
-    method_signature: str,
-    method_description: str,
+    jsonrpc_page_info: t.Callable[..., Page], method_title: str, method_signature: str, method_description: str
 ) -> None:
-    jsonrpc_page_info(
-        'types.python_stds_annotated.dictType', breadcrumb, method_title, method_signature, method_description
-    )
+    jsonrpc_page_info('types.python_stds_annotated.dictType', method_title, method_signature, method_description)
 
 
 @pytest.mark.parametrize(
@@ -593,26 +515,13 @@ def test_types_python_stds_dict_type_form(
 
 
 @pytest.mark.parametrize(
-    'breadcrumb,method_title,method_signature,method_description',
-    [
-        (
-            'types » types.python_stds_annotated.bytesType',
-            'types.python_stds_annotated.bytesType',
-            'types.python_stds_annotated.bytesType(b*: String) -> String',
-            '',
-        )
-    ],
+    'method_title,method_signature,method_description',
+    [('types.python_stds_annotated.bytesType', 'types.python_stds_annotated.bytesType(b*: String) -> String', '')],
 )
 def test_types_python_bytes_type_display(
-    jsonrpc_page_info: t.Callable[..., Page],
-    breadcrumb: str,
-    method_title: str,
-    method_signature: str,
-    method_description: str,
+    jsonrpc_page_info: t.Callable[..., Page], method_title: str, method_signature: str, method_description: str
 ) -> None:
-    jsonrpc_page_info(
-        'types.python_stds_annotated.bytesType', breadcrumb, method_title, method_signature, method_description
-    )
+    jsonrpc_page_info('types.python_stds_annotated.bytesType', method_title, method_signature, method_description)
 
 
 @pytest.mark.parametrize(
@@ -678,10 +587,9 @@ def test_types_python_bytes_type_form(
 
 
 @pytest.mark.parametrize(
-    'breadcrumb,method_title,method_signature,method_description',
+    'method_title,method_signature,method_description',
     [
         (
-            'types » types.python_stds_annotated.bytearrayType',
             'types.python_stds_annotated.bytearrayType',
             'types.python_stds_annotated.bytearrayType(b*: String) -> String',
             '',
@@ -689,15 +597,9 @@ def test_types_python_bytes_type_form(
     ],
 )
 def test_types_python_bytearray_type_display(
-    jsonrpc_page_info: t.Callable[..., Page],
-    breadcrumb: str,
-    method_title: str,
-    method_signature: str,
-    method_description: str,
+    jsonrpc_page_info: t.Callable[..., Page], method_title: str, method_signature: str, method_description: str
 ) -> None:
-    jsonrpc_page_info(
-        'types.python_stds_annotated.bytearrayType', breadcrumb, method_title, method_signature, method_description
-    )
+    jsonrpc_page_info('types.python_stds_annotated.bytearrayType', method_title, method_signature, method_description)
 
 
 @pytest.mark.parametrize(
@@ -771,26 +673,13 @@ def test_types_python_bytearray_type_form(
 
 
 @pytest.mark.parametrize(
-    'breadcrumb,method_title,method_signature,method_description',
-    [
-        (
-            'types » types.python_stds_annotated.intEnumType',
-            'types.python_stds_annotated.intEnumType',
-            'types.python_stds_annotated.intEnumType(e*: Object) -> Object',
-            '',
-        )
-    ],
+    'method_title,method_signature,method_description',
+    [('types.python_stds_annotated.intEnumType', 'types.python_stds_annotated.intEnumType(e*: Object) -> Object', '')],
 )
 def test_types_python_int_enum_type_display(
-    jsonrpc_page_info: t.Callable[..., Page],
-    breadcrumb: str,
-    method_title: str,
-    method_signature: str,
-    method_description: str,
+    jsonrpc_page_info: t.Callable[..., Page], method_title: str, method_signature: str, method_description: str
 ) -> None:
-    jsonrpc_page_info(
-        'types.python_stds_annotated.intEnumType', breadcrumb, method_title, method_signature, method_description
-    )
+    jsonrpc_page_info('types.python_stds_annotated.intEnumType', method_title, method_signature, method_description)
 
 
 @pytest.mark.parametrize(
@@ -838,26 +727,13 @@ def test_types_python_int_enum_type_form(
 
 
 @pytest.mark.parametrize(
-    'breadcrumb,method_title,method_signature,method_description',
-    [
-        (
-            'types » types.python_stds_annotated.decimalType',
-            'types.python_stds_annotated.decimalType',
-            'types.python_stds_annotated.decimalType(n*: Number) -> Number',
-            '',
-        )
-    ],
+    'method_title,method_signature,method_description',
+    [('types.python_stds_annotated.decimalType', 'types.python_stds_annotated.decimalType(n*: Number) -> Number', '')],
 )
 def test_types_python_decimal_type_display(
-    jsonrpc_page_info: t.Callable[..., Page],
-    breadcrumb: str,
-    method_title: str,
-    method_signature: str,
-    method_description: str,
+    jsonrpc_page_info: t.Callable[..., Page], method_title: str, method_signature: str, method_description: str
 ) -> None:
-    jsonrpc_page_info(
-        'types.python_stds_annotated.decimalType', breadcrumb, method_title, method_signature, method_description
-    )
+    jsonrpc_page_info('types.python_stds_annotated.decimalType', method_title, method_signature, method_description)
 
 
 @pytest.mark.parametrize(
@@ -925,26 +801,13 @@ def test_types_python_decimal_type_form(
 
 
 @pytest.mark.parametrize(
-    'breadcrumb,method_title,method_signature,method_description',
-    [
-        (
-            'types » types.python_stds_annotated.tupleType',
-            'types.python_stds_annotated.tupleType',
-            'types.python_stds_annotated.tupleType(tn*: Array) -> Array',
-            '',
-        )
-    ],
+    'method_title,method_signature,method_description',
+    [('types.python_stds_annotated.tupleType', 'types.python_stds_annotated.tupleType(tn*: Array) -> Array', '')],
 )
 def test_types_python_tuple_type_display(
-    jsonrpc_page_info: t.Callable[..., Page],
-    breadcrumb: str,
-    method_title: str,
-    method_signature: str,
-    method_description: str,
+    jsonrpc_page_info: t.Callable[..., Page], method_title: str, method_signature: str, method_description: str
 ) -> None:
-    jsonrpc_page_info(
-        'types.python_stds_annotated.tupleType', breadcrumb, method_title, method_signature, method_description
-    )
+    jsonrpc_page_info('types.python_stds_annotated.tupleType', method_title, method_signature, method_description)
 
 
 @pytest.mark.parametrize(
@@ -992,10 +855,9 @@ def test_types_python_tuple_type_form(
 
 
 @pytest.mark.parametrize(
-    'breadcrumb,method_title,method_signature,method_description',
+    'method_title,method_signature,method_description',
     [
         (
-            'types » types.python_stds_annotated.namedtupleType',
             'types.python_stds_annotated.namedtupleType',
             'types.python_stds_annotated.namedtupleType(tn*: Object) -> Array',
             '',
@@ -1003,15 +865,9 @@ def test_types_python_tuple_type_form(
     ],
 )
 def test_types_python_namedtuple_type_display(
-    jsonrpc_page_info: t.Callable[..., Page],
-    breadcrumb: str,
-    method_title: str,
-    method_signature: str,
-    method_description: str,
+    jsonrpc_page_info: t.Callable[..., Page], method_title: str, method_signature: str, method_description: str
 ) -> None:
-    jsonrpc_page_info(
-        'types.python_stds_annotated.namedtupleType', breadcrumb, method_title, method_signature, method_description
-    )
+    jsonrpc_page_info('types.python_stds_annotated.namedtupleType', method_title, method_signature, method_description)
 
 
 @pytest.mark.parametrize(
@@ -1083,26 +939,13 @@ def test_types_python_namedtuple_type_form(
 
 
 @pytest.mark.parametrize(
-    'breadcrumb,method_title,method_signature,method_description',
-    [
-        (
-            'types » types.python_stds_annotated.setType',
-            'types.python_stds_annotated.setType',
-            'types.python_stds_annotated.setType(s*: Array) -> Array',
-            '',
-        )
-    ],
+    'method_title,method_signature,method_description',
+    [('types.python_stds_annotated.setType', 'types.python_stds_annotated.setType(s*: Array) -> Array', '')],
 )
 def test_types_python_set_type_display(
-    jsonrpc_page_info: t.Callable[..., Page],
-    breadcrumb: str,
-    method_title: str,
-    method_signature: str,
-    method_description: str,
+    jsonrpc_page_info: t.Callable[..., Page], method_title: str, method_signature: str, method_description: str
 ) -> None:
-    jsonrpc_page_info(
-        'types.python_stds_annotated.setType', breadcrumb, method_title, method_signature, method_description
-    )
+    jsonrpc_page_info('types.python_stds_annotated.setType', method_title, method_signature, method_description)
 
 
 @pytest.mark.parametrize(
@@ -1150,26 +993,13 @@ def test_types_python_set_type_form(
 
 
 @pytest.mark.parametrize(
-    'breadcrumb,method_title,method_signature,method_description',
-    [
-        (
-            'types » types.python_stds_annotated.sequenceType',
-            'types.python_stds_annotated.sequenceType',
-            'types.python_stds_annotated.sequenceType(s*: Array) -> Array',
-            '',
-        )
-    ],
+    'method_title,method_signature,method_description',
+    [('types.python_stds_annotated.sequenceType', 'types.python_stds_annotated.sequenceType(s*: Array) -> Array', '')],
 )
 def test_types_python_sequence_type_display(
-    jsonrpc_page_info: t.Callable[..., Page],
-    breadcrumb: str,
-    method_title: str,
-    method_signature: str,
-    method_description: str,
+    jsonrpc_page_info: t.Callable[..., Page], method_title: str, method_signature: str, method_description: str
 ) -> None:
-    jsonrpc_page_info(
-        'types.python_stds_annotated.sequenceType', breadcrumb, method_title, method_signature, method_description
-    )
+    jsonrpc_page_info('types.python_stds_annotated.sequenceType', method_title, method_signature, method_description)
 
 
 @pytest.mark.parametrize(
@@ -1235,10 +1065,9 @@ def test_types_python_sequence_type_form(
 
 
 @pytest.mark.parametrize(
-    'breadcrumb,method_title,method_signature,method_description',
+    'method_title,method_signature,method_description',
     [
         (
-            'types » types.python_stds_annotated.typedDictType',
             'types.python_stds_annotated.typedDictType',
             'types.python_stds_annotated.typedDictType(user*: Object) -> Object',
             '',
@@ -1246,15 +1075,9 @@ def test_types_python_sequence_type_form(
     ],
 )
 def test_types_python_typed_dict_type_display(
-    jsonrpc_page_info: t.Callable[..., Page],
-    breadcrumb: str,
-    method_title: str,
-    method_signature: str,
-    method_description: str,
+    jsonrpc_page_info: t.Callable[..., Page], method_title: str, method_signature: str, method_description: str
 ) -> None:
-    jsonrpc_page_info(
-        'types.python_stds_annotated.typedDictType', breadcrumb, method_title, method_signature, method_description
-    )
+    jsonrpc_page_info('types.python_stds_annotated.typedDictType', method_title, method_signature, method_description)
 
 
 @pytest.mark.parametrize(
@@ -1326,10 +1149,9 @@ def test_types_python_typed_dict_type_form(
 
 
 @pytest.mark.parametrize(
-    'breadcrumb,method_title,method_signature,method_description',
+    'method_title,method_signature,method_description',
     [
         (
-            'types » types.python_stds_annotated.unionWithTwoTypes',
             'types.python_stds_annotated.unionWithTwoTypes',
             'types.python_stds_annotated.unionWithTwoTypes(n*: Number) -> Number',
             '',
@@ -1337,14 +1159,10 @@ def test_types_python_typed_dict_type_form(
     ],
 )
 def test_types_python_union_with_two_types_display(
-    jsonrpc_page_info: t.Callable[..., Page],
-    breadcrumb: str,
-    method_title: str,
-    method_signature: str,
-    method_description: str,
+    jsonrpc_page_info: t.Callable[..., Page], method_title: str, method_signature: str, method_description: str
 ) -> None:
     jsonrpc_page_info(
-        'types.python_stds_annotated.unionWithTwoTypes', breadcrumb, method_title, method_signature, method_description
+        'types.python_stds_annotated.unionWithTwoTypes', method_title, method_signature, method_description
     )
 
 
@@ -1411,26 +1229,13 @@ def test_types_python_union_with_two_types_form(
 
 
 @pytest.mark.parametrize(
-    'breadcrumb,method_title,method_signature,method_description',
-    [
-        (
-            'types » types.python_stds_annotated.literalType',
-            'types.python_stds_annotated.literalType',
-            'types.python_stds_annotated.literalType(x*: String) -> String',
-            '',
-        )
-    ],
+    'method_title,method_signature,method_description',
+    [('types.python_stds_annotated.literalType', 'types.python_stds_annotated.literalType(x*: String) -> String', '')],
 )
 def test_types_python_literal_type_display(
-    jsonrpc_page_info: t.Callable[..., Page],
-    breadcrumb: str,
-    method_title: str,
-    method_signature: str,
-    method_description: str,
+    jsonrpc_page_info: t.Callable[..., Page], method_title: str, method_signature: str, method_description: str
 ) -> None:
-    jsonrpc_page_info(
-        'types.python_stds_annotated.literalType', breadcrumb, method_title, method_signature, method_description
-    )
+    jsonrpc_page_info('types.python_stds_annotated.literalType', method_title, method_signature, method_description)
 
 
 @pytest.mark.parametrize(
@@ -1478,26 +1283,13 @@ def test_types_python_literal_type_form(
 
 
 @pytest.mark.parametrize(
-    'breadcrumb,method_title,method_signature,method_description',
-    [
-        (
-            'types » types.python_stds_annotated.optional',
-            'types.python_stds_annotated.optional',
-            'types.python_stds_annotated.optional(n: Number) -> Number',
-            '',
-        )
-    ],
+    'method_title,method_signature,method_description',
+    [('types.python_stds_annotated.optional', 'types.python_stds_annotated.optional(n: Number) -> Number', '')],
 )
 def test_types_python_optional_display(
-    jsonrpc_page_info: t.Callable[..., Page],
-    breadcrumb: str,
-    method_title: str,
-    method_signature: str,
-    method_description: str,
+    jsonrpc_page_info: t.Callable[..., Page], method_title: str, method_signature: str, method_description: str
 ) -> None:
-    jsonrpc_page_info(
-        'types.python_stds_annotated.optional', breadcrumb, method_title, method_signature, method_description
-    )
+    jsonrpc_page_info('types.python_stds_annotated.optional', method_title, method_signature, method_description)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Introduce a powerful generator-based middleware system to the Flask-JSONRPC Browse API, enabling request/response interception, authentication, and authorization workflows. The implementation includes a complete example demonstrating JWT-based authentication for the Petstore API.

1. Middleware Registration System New register_middleware decorator allows registering custom middleware that intercepts requests before they reach route handlers and responses before they're sent to clients.

* Generator-based middleware with before_request, after_request, and teardown_request lifecycle hooks
* Middleware can return early to intercept requests, continue processing, or skip execution
* Automatic cleanup via Flask's teardown mechanism

2. Middleware Lifecycle Control

Middlewares use generator protocol for fine-grained control:

* yield False - Skip this middleware, continue to next
* yield True - Continue processing and run after-request phase
* yield response - Early return, intercept request immediately
* response = yield - Receive response in after-request phase

3. Custom Login/Logout Templates

Browse API now supports custom authentication pages via:

* BROWSE_LOGIN_TEMPLATE setting
* BROWSE_LOGOUT_TEMPLATE setting
* /login and /logout routes automatically registered

Complete Middleware Admin Example
Here's a production-ready JWT authentication middleware from the Petstore example: https://github.com/cenobites/flask-jsonrpc/blob/master/examples/rpcdescribe/src/petstore/app.py

Authorization Middleware:
```
@register_middleware('authorization')
def authorization_middleware(request):
    # Check user permissions
    jwt_claims = flask_jwt.get_jwt()
    if 'admin' not in jwt_claims.get('roles', []):
        yield jsonify({'error': 'Forbidden'}), 403
        return

    response = yield True
    # Add custom headers
    response.headers['X-Admin-Access'] = 'true'
    yield
```

Logging Middleware:
```
@register_middleware('logging')
def logging_middleware(request):
    start_time = time.time()

    response = yield True

    duration = time.time() - start_time
    app.logger.info(f'{request.method} {request.path} - {response.status_code} - {duration:.3f}s')
    yield
```

Rate Limiting Middleware:
```
@register_middleware('rate_limit')
def rate_limit_middleware(request):
    user_id = flask_jwt.get_jwt_identity()
    if is_rate_limited(user_id):
        yield jsonify({'error': 'Too many requests'}), 429
        return

    yield True  # Continue processing
```

Resolves: #370
See: #373

<!--
## The seven rules of a great Git commit message

:: Keep in mind: This has all been said before.

1. Separate subject from body with a blank line
2. Limit the subject line to 50 characters
3. Capitalize the subject line
4. Do not end the subject line with a period
5. Use the imperative mood in the subject line
6. Wrap the body at 72 characters
7. Use the body to explain what and why vs. how

For example:

```
Summarize changes in around 50 characters or less

More detailed explanatory text, if necessary. Wrap it to about 72
characters or so. In some contexts, the first line is treated as the
subject of the commit and the rest of the text as the body. The
blank line separating the summary from the body is critical (unless
you omit the body entirely); various tools like `log`, `shortlog`
and `rebase` can get confused if you run the two together.

Explain the problem that this commit is solving. Focus on why you
are making this change as opposed to how (the code explains that).
Are there side effects or other unintuitive consequences of this
change? Here's the place to explain them.

Further paragraphs come after blank lines.

 - Bullet points are okay, too

 - Typically a hyphen or asterisk is used for the bullet, preceded
   by a single space, with blank lines in between, but conventions
   vary here

If you use an issue tracker, put references to them at the bottom,
like this:

Resolves: #123
See also: #456, #789
```

More details: https://chris.beams.io/posts/git-commit/.
-->